### PR TITLE
fix(user): Use '*' as default password field rather than '!'

### DIFF
--- a/system/user.go
+++ b/system/user.go
@@ -34,6 +34,8 @@ func CreateUser(u *User) error {
 
 	if u.PasswordHash != "" {
 		args = append(args, "--password", u.PasswordHash)
+	} else {
+		args = append(args, "--password", "*")
 	}
 
 	if u.GECOS != "" {


### PR DESCRIPTION
When using openssh without pam it checks for a ! prefix in the password
field, locking the account entirely if found. The other common lock
character, *, is allowed by ssh to login via ssh keys so use it instead.

Note: haven't actually tested this, it's time for bed so will do that tomorrow...
