### PR TITLE
fix(initialize): don't quote version or ID

### DIFF
--- a/initialize/oem.go
+++ b/initialize/oem.go
@@ -18,9 +18,9 @@ type OEMRelease struct {
 
 func (oem *OEMRelease) String() string {
 	fields := []string{
-		fmt.Sprintf("ID=%q", oem.ID),
+		fmt.Sprintf("ID=%s", oem.ID),
+		fmt.Sprintf("VERSION_ID=%s", oem.VersionID),
 		fmt.Sprintf("NAME=%q", oem.Name),
-		fmt.Sprintf("VERSION_ID=%q", oem.VersionID),
 		fmt.Sprintf("HOME_URL=%q", oem.HomeURL),
 		fmt.Sprintf("BUG_REPORT_URL=%q", oem.BugReportURL),
 	}

--- a/initialize/oem_test.go
+++ b/initialize/oem_test.go
@@ -42,9 +42,9 @@ func TestOEMReleaseWrittenToDisk(t *testing.T) {
 		t.Fatalf("Unable to read expected file: %v", err)
 	}
 
-	expect := `ID="rackspace"
+	expect := `ID=rackspace
+VERSION_ID=168.0.0
 NAME="Rackspace Cloud Servers"
-VERSION_ID="168.0.0"
 HOME_URL="https://www.rackspace.com/cloud/servers/"
 BUG_REPORT_URL="https://github.com/coreos/coreos-overlay"
 `


### PR DESCRIPTION
The update_engine parsing and XML generation code is very naive. Instead of
trying to implement a correct parser and generater in C++ just generate a file
that doesn't have quote's around fields that we know won't have spaces.

/cc @robszumski @marineam @bcwaldon
