### PR TITLE
fix(units): Relax ordering requirements for now.

### DIFF
--- a/units/user-cloudinit@.service
+++ b/units/user-cloudinit@.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Load cloud-config from %f
-Requires=system-config.target
-After=system-config.target
+Requires=coreos-setup-environment.service
+After=coreos-setup-environment.service
 Before=user-config.target
 ConditionFileNotEmpty=%f
 


### PR DESCRIPTION
The current cloudinit implementation blocks when starting units which
causes it to deadlock the boot process if a system cloud config starts a
user cloud config because the user configs want to run after system is
done. Until cloudinit switches to non-blocking calls user configs will
go back to just depending on coreos-setup-environment.service.
