### PR TITLE
feat(proc-cmdline): Add proc-cmdline unit

### DIFF
--- a/units/user-cloudinit-proc-cmdline.service
+++ b/units/user-cloudinit-proc-cmdline.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Load cloud-config from url defined in /proc/cmdline
+Requires=coreos-setup-environment.service
+After=coreos-setup-environment.service
+Before=user-config.target
+ConditionKernelCommandLine=cloud-config-url
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+EnvironmentFile=-/etc/environment
+ExecStart=/usr/bin/coreos-cloudinit --from-proc-cmdline

--- a/units/user-config.target
+++ b/units/user-config.target
@@ -6,3 +6,6 @@ After=system-config.target
 # Load user_data placed by coreos-install
 Requires=user-cloudinit@var-lib-coreos\x2dinstall-user_data.service
 After=user-cloudinit@var-lib-coreos\x2dinstall-user_data.service
+
+Requires=user-cloudinit-proc-cmdline.service
+After=user-cloudinit-proc-cmdline.service


### PR DESCRIPTION
This unit will always be started, but will only do anything if
a `cloud-config-url=<url>` token is provided in /proc/cmdline.
