### PR TITLE
fix(docs): start the example unit

### DIFF
--- a/Documentation/cloud-config.md
+++ b/Documentation/cloud-config.md
@@ -130,6 +130,7 @@ Write a unit to disk, automatically starting it.
 coreos:
     units:
       - name: docker-redis.service
+        command: start
         content: |
           [Unit]
           Description=Redis container


### PR DESCRIPTION
> Write a unit to disk, automatically starting it.

We weren't actually starting this.
