### PR TITLE
Revert "fix(units): Drop automatic daemon-reload"

### DIFF
--- a/initialize/config.go
+++ b/initialize/config.go
@@ -161,6 +161,10 @@ func Apply(cfg CloudConfig, env *Environment) error {
 			}
 		}
 
+		if err := system.DaemonReload(); err != nil {
+			log.Fatalf("Failed systemd daemon-reload: %v", err)
+		}
+
 		for unit, command := range commands {
 			log.Printf("Calling unit command '%s %s'", command, unit)
 			res, err := system.RunUnitCommand(command, unit)


### PR DESCRIPTION
daemon-reload should be fixed now and the latest CoreOS with locksmith
is causing the etcd unit to get lazy-loaded before all the cloudinit
processes have finished configuring etcd via dropin files. In short,
the luck we were relying on to get by without daemon-reload has
officially run out. Cross your fingers!

This reverts commit 580460ff3f0dba4aa6ba655d54965cbfd184137a.
