### PR TITLE
users[i].primary-group option seems invalid

### DIFF
--- a/system/user.go
+++ b/system/user.go
@@ -53,7 +53,7 @@ func CreateUser(u *User) error {
 	}
 
 	if u.PrimaryGroup != "" {
-		args = append(args, "--primary-group", u.PrimaryGroup)
+		args = append(args, "--gid", u.PrimaryGroup)
 	}
 
 	if len(u.Groups) > 0 {


### PR DESCRIPTION
Based on the documentation I saw [here](https://coreos.com/docs/cluster-management/setup/cloudinit-cloud-config#users), I set up the following in my cloud-config:

``` yaml
#cloud-config
# ...
users:
- no-user-group: true
  primary-group: docker
  name: rtlong
  coreos-ssh-import-github: rtlong
# ...
```

(I'm not certain this is the best approach to configuring users, any way, but nevertheless, this ought to work, per the docs.)

And I see this error when it boots the machine:

```
coreos-cloudinit[3017]: 2014/04/18 00:06:37 Fetching user-data from datasource of type "metadata-service"
coreos-cloudinit[3017]: 2014/04/18 00:06:37 Parsing user-data as cloud-config
coreos-cloudinit[3017]: 2014/04/18 00:06:37 Creating user 'rtlong'
coreos-cloudinit[3017]: 2014/04/18 00:06:38 Command 'useradd --password * --create-home --primary-group docker --no-user-group rtlong' failed: exit
coreos-cloudinit[3017]: useradd: unrecognized option '--primary-group'
coreos-cloudinit[3017]: Usage: useradd [options] LOGIN
coreos-cloudinit[3017]: useradd -D
coreos-cloudinit[3017]: useradd -D [options]
coreos-cloudinit[3017]: Options:
coreos-cloudinit[3017]: -b, --base-dir BASE_DIR       base directory for the home directory of the new account
coreos-cloudinit[3017]: -c, --comment COMMENT         GECOS field of the new account
coreos-cloudinit[3017]: -d, --home-dir HOME_DIR       home directory of the new account
coreos-cloudinit[3017]: -D, --defaults                print or change default useradd configuration
coreos-cloudinit[3017]: -e, --expiredate EXPIRE_DATE  expiration date of the new account
coreos-cloudinit[3017]: -f, --inactive INACTIVE       password inactivity period of the new account
coreos-cloudinit[3017]: -g, --gid GROUP               name or ID of the primary group of the new account
coreos-cloudinit[3017]: -G, --groups GROUPS           list of supplementary groups of the new account
coreos-cloudinit[3017]: -h, --help                    display this help message and exit
coreos-cloudinit[3017]: -k, --skel SKEL_DIR           use this alternative skeleton directory
coreos-cloudinit[3017]: -K, --key KEY=VALUE           override /etc/login.defs defaults
coreos-cloudinit[3017]: -l, --no-log-init             do not add the user to the lastlog and faillog databases
coreos-cloudinit[3017]: -m, --create-home             create the user's home directory
coreos-cloudinit[3017]: -M, --no-create-home          do not create the user's home directory
coreos-cloudinit[3017]: -N, --no-user-group           do not create a group with the same name as the user
coreos-cloudinit[3017]: -o, --non-unique              allow to create users with duplicate (non-unique) UID
coreos-cloudinit[3017]: -p, --password PASSWORD       encrypted password of the new account
coreos-cloudinit[3017]: -r, --system                  create a system account
coreos-cloudinit[3017]: -R, --root CHROOT_DIR         directory to chroot into
coreos-cloudinit[3017]: -s, --shell SHELL             login shell of the new account
coreos-cloudinit[3017]: -u, --uid UID                 user ID of the new account
coreos-cloudinit[3017]: -U, --user-group              create a group with the same name as the user
coreos-cloudinit[3017]: 2014/04/18 00:06:38 Failed creating user 'rtlong': exit status 2
coreos-cloudinit[3017]: 2014/04/18 00:06:38 Failed resolving user-data: exit status 2
systemd[1]: ec2-cloudinit.service: main process exited, code=exited, status=1/FAILURE
systemd[1]: Failed to start Cloudinit from EC2-style metadata.
systemd[1]: Unit ec2-cloudinit.service entered failed state.
```

It seems it should be using the `--gid` option to `useradd`, instead?
