### PR TITLE
Warn or error on unrecognized keys in cloud-config.yml

### DIFF
--- a/initialize/config_test.go
+++ b/initialize/config_test.go
@@ -18,6 +18,14 @@ section_unknown:
     something
 bare_unknown:
   bar
+write_files:
+  - content: fun
+    path: /var/party
+    file_unknown: nofun
+users:
+  - name: fry
+    passwd: somehash
+    user_unknown: philip
 hostname:
   foo
 `
@@ -30,6 +38,12 @@ hostname:
 	}
 	if len(cfg.Coreos.Etcd) < 1 {
 		t.Fatalf("etcd section not correctly set when invalid keys are present")
+	}
+	if len(cfg.WriteFiles) < 1 || cfg.WriteFiles[0].Content != "fun" || cfg.WriteFiles[0].Path != "/var/party" {
+		t.Fatalf("write_files section not correctly set when invalid keys are present")
+	}
+	if len(cfg.Users) < 1 || cfg.Users[0].Name != "fry" || cfg.Users[0].PasswordHash != "somehash" {
+		t.Fatalf("users section not correctly set when invalid keys are present")
 	}
 
 	var warnings string
@@ -47,6 +61,12 @@ hostname:
 	}
 	if !strings.Contains(warnings, "section_unknown") {
 		t.Errorf("warnings did not catch unrecognized key section_unknown")
+	}
+	if !strings.Contains(warnings, "user_unknown") {
+		t.Errorf("warnings did not catch unrecognized user key user_unknown")
+	}
+	if !strings.Contains(warnings, "file_unknown") {
+		t.Errorf("warnings did not catch unrecognized file key file_unknown")
 	}
 }
 


### PR DESCRIPTION
I had a cloud-config.yml that looked like this:

```
#cloud-config

units:
  - name: static.network
    content: |
[...]
```

The other stanzas were working just fine, but `units` was being silently ignored. Of course, the correct key was actually `coreos.units` -- but the behavior of silently ignoring the unknown `units` key, instead of throwing an error, made this unnecessarily hard to figure out.

I suggest that if any keys are laying around in cloud-config.yml that shouldn't be, cloud-init should at least warn that it's going to ignore them. (It could also just error out entirely, though this would probably harm reuse of cloud-config.yml files generated by foreign stacks.)
