### PR TITLE
Response body must not be closed if request error'd.

### DIFF
--- a/initialize/ssh_keys.go
+++ b/initialize/ssh_keys.go
@@ -26,10 +26,10 @@ func SSHImportKeysFromURL(system_user string, url string) error {
 
 func fetchUserKeys(url string) ([]string, error) {
 	res, err := http.Get(url)
-	defer res.Body.Close()
 	if err != nil {
 		return nil, err
 	}
+	defer res.Body.Close()
 	body, err := ioutil.ReadAll(res.Body)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
`defer res.Body.Close()` always needs to be called after the `err` handling, since `res` is nil if `err` isn't.
