### PR TITLE
chore(logging): Removes duplicated timestamp during booting

### DIFF
--- a/coreos-cloudinit.go
+++ b/coreos-cloudinit.go
@@ -13,6 +13,11 @@ import (
 
 const version = "0.6.0+git"
 
+func init() {
+	//Removes timestamp since it is displayed already during booting
+	log.SetFlags(0)
+}
+
 func main() {
 	var printVersion bool
 	flag.BoolVar(&printVersion, "version", false, "Print the version and exit")


### PR DESCRIPTION
I did not test this during booting to see how it looks like because I haven't been able to get the SDK setup locally (https://github.com/coreos/bugs/issues/25)
