### PR TITLE
removed tricky space from cloud-config header

### DIFF
--- a/Documentation/cloud-config.md
+++ b/Documentation/cloud-config.md
@@ -151,7 +151,7 @@ coreos:
 Start the built-in `etcd` and `fleet` services:
 
 ```
-# cloud-config
+#cloud-config
 
 coreos:
     units:


### PR DESCRIPTION
Not really a big deal, but a quick copy and paste had me pulling my hair out for a couple hours :\
