### PR TITLE
ec2-cloudinit service fails after reboot with "reboot-strategy: off"

### DIFF
--- a/Documentation/cloud-config.md
+++ b/Documentation/cloud-config.md
@@ -123,6 +123,7 @@ The `coreos.units.*` parameters define a list of arbitrary systemd units to star
 - **enable**: Boolean indicating whether or not to handle the [Install] section of the unit file. This is similar to running `systemctl enable <name>`. Default value is false.
 - **content**: Plaintext string representing entire unit file. If no value is provided, the unit is assumed to exist already.
 - **command**: Command to execute on unit: start, stop, reload, restart, try-restart, reload-or-restart, reload-or-try-restart. Default value is restart.
+- **mask**: Whether to mask the unit file by symlinking it to `/dev/null` (analogous to `systemctl mask <name>`). Note that unlike `systemctl mask`, **this will destructively remove any existing unit file** located at `/etc/systemd/system/<unit>`, to ensure that the mask succeeds. Default value is false.
 
 **NOTE:** The command field is ignored for all network, netdev, and link units. The systemd-networkd.service unit will be restarted in their place.
 


### PR DESCRIPTION
Steps to reproduce:

Boot a CoreOS machine with the following cloud-config:

```
#cloud-config
coreos:
    update:
        reboot-strategy: off
```

On first boot, everything is fine.  journalctl reports:

```
systemd[1]: Starting Cloudinit from EC2-style metadata...
coreos-cloudinit[3434]: 2014/05/21 17:27:14 Fetching user-data from datasource of type "metadata-service"
coreos-cloudinit[3434]: 2014/05/21 17:27:14 Parsing user-data as cloud-config
coreos-cloudinit[3434]: 2014/05/21 17:27:14 Wrote locksmith config file to filesystem
systemd[1]: Started Cloudinit from EC2-style metadata.
```

Reboot the system.  Now we see:

```
-- Reboot --
systemd[1]: Starting Cloudinit from EC2-style metadata...
coreos-cloudinit[3639]: 2014/05/21 17:28:51 Fetching user-data from datasource of type "metadata-service"
coreos-cloudinit[3639]: 2014/05/21 17:28:51 Parsing user-data as cloud-config
coreos-cloudinit[3639]: 2014/05/21 17:28:51 Failed to write locksmith config to filesystem: symlink /dev/null /etc/systemd
systemd[1]: ec2-cloudinit.service: main process exited, code=exited, status=1/FAILURE
systemd[1]: Failed to start Cloudinit from EC2-style metadata.
systemd[1]: Unit ec2-cloudinit.service entered failed state.

```

FWIW, the version I'm running:

```
$ cat /etc/lsb-release
DISTRIB_ID=CoreOS
DISTRIB_RELEASE=317.0.0
DISTRIB_CODENAME="Let the tiger loose!"
DISTRIB_DESCRIPTION="CoreOS 317.0.0"
```
