### PR TITLE
Dies trying to enable non-existent /etc/systemd/system/locksmithd.service

### DIFF
--- a/initialize/update.go
+++ b/initialize/update.go
@@ -136,13 +136,11 @@ func (uc UpdateConfig) Unit(root string) (*system.Unit, error) {
 
 	u := &system.Unit{
 		Name:    locksmithUnit,
-		Enable:  true,
 		Command: "restart",
 		Mask:    false,
 	}
 
 	if strategy == "off" {
-		u.Enable = false
 		u.Command = "stop"
 		u.Mask = true
 	}


### PR DESCRIPTION
After the latest update...

cloud-config.yml:

```
#cloud-config
coreos:
  update:
    reboot-strategy: reboot
```

error:

```
$ sudo /usr/bin/coreos-cloudinit --from-file /usr/share/oem/cloud-config.yml 
2014/05/24 02:44:55 Fetching user-data from datasource of type "local-file"
2014/05/24 02:44:55 Parsing user-data as cloud-config
2014/05/24 02:44:55 Wrote file /etc/coreos/update.conf to filesystem
2014/05/24 02:44:55 Enabling unit file /etc/systemd/system/locksmithd.service
2014/05/24 02:44:55 Failed resolving user-data: No such file or directory
```

versions:

```
$ /usr/bin/coreos-cloudinit --version             
coreos-cloudinit version 0.7.1
$ grep VERSION= /etc/os-release 
VERSION=324.1.0
```
