### PR TITLE
"Enable" option does not support units in /usr/lib64/systemd 

### DIFF
--- a/initialize/config.go
+++ b/initialize/config.go
@@ -254,8 +254,8 @@ func Apply(cfg CloudConfig, env *Environment) error {
 
 		if unit.Enable {
 			if unit.Group() != "network" {
-				log.Printf("Enabling unit file %s", dst)
-				if err := system.EnableUnitFile(dst, unit.Runtime); err != nil {
+				log.Printf("Enabling unit file %s", unit.Name)
+				if err := system.EnableUnitFile(unit.Name, unit.Runtime); err != nil {
 					return err
 				}
 				log.Printf("Enabled unit %s", unit.Name)

--- a/system/systemd.go
+++ b/system/systemd.go
@@ -91,14 +91,14 @@ func PlaceUnit(u *Unit, dst string) error {
 	return nil
 }
 
-func EnableUnitFile(file string, runtime bool) error {
+func EnableUnitFile(unit string, runtime bool) error {
 	conn, err := dbus.New()
 	if err != nil {
 		return err
 	}
 
-	files := []string{file}
-	_, _, err = conn.EnableUnitFiles(files, runtime, true)
+	units := []string{unit}
+	_, _, err = conn.EnableUnitFiles(units, runtime, true)
 	return err
 }
 


### PR DESCRIPTION
On CoreOS 324.1.0, using the config:

``` yaml
#cloud-config

coreos:
  etcd:
    addr: $private_ipv4:4001
    peer-addr: $private_ipv4:7001
  units:
    - name: etcd.service
      enable: true
      command: start
  update:
    reboot-strategy: "etcd-lock"
```

After login:

```
CoreOS (alpha)
Failed Units: 2
  ec2-cloudinit.service
  user-cloudinit@media-configdrive-openstack-latest-user_data.service
core@coreos ~ $ sudo systemctl status ec2-cloudinit
● ec2-cloudinit.service - Cloudinit from EC2-style metadata
   Loaded: loaded (/run/systemd/system/ec2-cloudinit.service; static)
   Active: failed (Result: exit-code) since Mon 2014-05-26 04:20:50 UTC; 4min 23s ago
  Process: 3032 ExecStart=/usr/bin/coreos-cloudinit -ignore-failure=true -from-url=http://169.254.169.254/latest/user-data (code=exited, status=1/FAILURE)
 Main PID: 3032 (code=exited, status=1/FAILURE)

May 26 04:20:50 coreos coreos-cloudinit[3032]: 2014/05/26 04:20:50 Fetching user-data from datasource of type "metadata-service"
May 26 04:20:50 coreos coreos-cloudinit[3032]: 2014/05/26 04:20:50 Fetching user-data from http://169.254.169.254/latest/user-data. Attempt #1
May 26 04:20:50 coreos coreos-cloudinit[3032]: 2014/05/26 04:20:50 Parsing user-data as cloud-config
May 26 04:20:50 coreos coreos-cloudinit[3032]: 2014/05/26 04:20:50 Wrote file /etc/coreos/update.conf to filesystem
May 26 04:20:50 coreos coreos-cloudinit[3032]: 2014/05/26 04:20:50 Enabling unit file /etc/systemd/system/etcd.service
May 26 04:20:50 coreos coreos-cloudinit[3032]: 2014/05/26 04:20:50 Failed resolving user-data: No such file or directory
May 26 04:20:50 coreos systemd[1]: ec2-cloudinit.service: main process exited, code=exited, status=1/FAILURE
May 26 04:20:50 coreos systemd[1]: Failed to start Cloudinit from EC2-style metadata.
May 26 04:20:50 coreos systemd[1]: Unit ec2-cloudinit.service entered failed state.
core@coreos ~ $ sudo systemctl status user-cloudinit@media-configdrive-openstack-latest-user_data.service
● user-cloudinit@media-configdrive-openstack-latest-user_data.service - Load cloud-config from /media/configdrive/openstack/latest/user_data
   Loaded: loaded (/usr/lib64/systemd/system/user-cloudinit@media-configdrive-openstack-latest-user_data.service; static)
   Active: failed (Result: exit-code) since Mon 2014-05-26 04:20:50 UTC; 4min 40s ago
  Process: 3039 ExecStart=/usr/bin/coreos-cloudinit --from-file=%f (code=exited, status=1/FAILURE)
 Main PID: 3039 (code=exited, status=1/FAILURE)

May 26 04:20:50 coreos coreos-cloudinit[3039]: 2014/05/26 04:20:50 Fetching user-data from datasource of type "local-file"
May 26 04:20:50 coreos coreos-cloudinit[3039]: 2014/05/26 04:20:50 Parsing user-data as cloud-config
May 26 04:20:50 coreos coreos-cloudinit[3039]: 2014/05/26 04:20:50 Wrote file /etc/coreos/update.conf to filesystem
May 26 04:20:50 coreos coreos-cloudinit[3039]: 2014/05/26 04:20:50 Enabling unit file /etc/systemd/system/etcd.service
May 26 04:20:50 coreos coreos-cloudinit[3039]: 2014/05/26 04:20:50 Failed resolving user-data: No such file or directory
May 26 04:20:50 coreos systemd[1]: user-cloudinit@media-configdrive-openstack-latest-user_data.service: main process exited, code=exited, status=1/FAILURE
May 26 04:20:50 coreos systemd[1]: Failed to start Load cloud-config from /media/configdrive/openstack/latest/user_data.
May 26 04:20:50 coreos systemd[1]: Unit user-cloudinit@media-configdrive-openstack-latest-user_data.service entered failed state.
core@coreos ~ $ cat /media/configdrive/openstack/latest/user_data
#cloud-config

coreos:
  etcd:
    addr: $private_ipv4:4001
    peer-addr: $private_ipv4:7001
  units:
    - name: etcd.service
      enable: true
      command: start
  update:
    reboot-strategy: "etcd-lock"
```
