### PR TITLE
etcdenvironment: order map keys consistently

### DIFF
--- a/initialize/etcd.go
+++ b/initialize/etcd.go
@@ -3,6 +3,7 @@ package initialize
 import (
 	"errors"
 	"fmt"
+	"sort"
 
 	"github.com/coreos/coreos-cloudinit/system"
 )
@@ -19,9 +20,16 @@ func (ee EtcdEnvironment) String() (out string) {
 		}
 	}
 
+	var sorted sort.StringSlice
+	for k, _ := range norm {
+		sorted = append(sorted, k)
+	}
+	sorted.Sort()
+
 	out += "[Service]\n"
 
-	for key, val := range norm {
+	for _, key := range sorted {
+		val := norm[key]
 		out += fmt.Sprintf("Environment=\"ETCD_%s=%s\"\n", key, val)
 	}
 

--- a/initialize/etcd_test.go
+++ b/initialize/etcd_test.go
@@ -102,8 +102,8 @@ func TestEtcdEnvironmentWrittenToDisk(t *testing.T) {
 	}
 
 	expect := `[Service]
-Environment="ETCD_NAME=node001"
 Environment="ETCD_DISCOVERY=http://disco.example.com/foobar"
+Environment="ETCD_NAME=node001"
 Environment="ETCD_PEER_BIND_ADDR=127.0.0.1:7002"
 `
 	if string(contents) != expect {


### PR DESCRIPTION
http://golang.org/doc/go1.3#map
In this particular case I think it's cleaner to have a consistent order than
not care about it.
