### PR TITLE
coreos-cloudinit: restrict convert-netconf to configdrive

### DIFF
--- a/coreos-cloudinit.go
+++ b/coreos-cloudinit.go
@@ -55,8 +55,8 @@ func main() {
 		os.Exit(0)
 	}
 
-	if convertNetconf != "" && sources.configDrive == "" && !sources.metadataService {
-		fmt.Println("-convert-netconf flag requires -from-configdrive or -from-metadata-service")
+	if convertNetconf != "" && sources.configDrive == "" {
+		fmt.Println("-convert-netconf flag requires -from-configdrive")
 		os.Exit(1)
 	}
 


### PR DESCRIPTION
Until we figure out the story with doing this properly from metadata-service, just restrict it to config drive only.
