### PR TITLE
metadata-service: remove check for OpenStack meta_data.json

### DIFF
--- a/datasource/metadata_service.go
+++ b/datasource/metadata_service.go
@@ -27,7 +27,6 @@ const (
 	Ec2MetadataUrl       = BaseUrl + Ec2ApiVersion + "/meta-data"
 	OpenstackApiVersion  = "openstack/2012-08-10"
 	OpenstackUserdataUrl = BaseUrl + OpenstackApiVersion + "/user_data"
-	OpenstackMetadataUrl = BaseUrl + OpenstackApiVersion + "/meta_data.json"
 )
 
 type metadataService struct{}
@@ -80,12 +79,6 @@ func (ms *metadataService) Type() string {
 }
 
 func fetchMetadata(client getter) ([]byte, error) {
-	if metadata, err := client.GetRetry(OpenstackMetadataUrl); err == nil {
-		return metadata, nil
-	} else if _, ok := err.(pkg.ErrTimeout); ok {
-		return nil, err
-	}
-
 	attrs := make(map[string]interface{})
 	if keynames, err := fetchAttributes(client, fmt.Sprintf("%s/public-keys", Ec2MetadataUrl)); err == nil {
 		keyIDs := make(map[string]string)

--- a/datasource/metadata_service_test.go
+++ b/datasource/metadata_service_test.go
@@ -145,12 +145,6 @@ func TestFetchMetadata(t *testing.T) {
 			},
 			expect: []byte(`{"hostname":"host","network_config":{"content_path":"path"},"public_keys":{"test1":"key"}}`),
 		},
-		{
-			metadata: map[string]string{
-				"http://169.254.169.254/openstack/2012-08-10/meta_data.json": "test",
-			},
-			expect: []byte("test"),
-		},
 		{err: pkg.ErrTimeout{fmt.Errorf("test error")}},
 	} {
 		client := &TestHttpClient{tt.metadata, tt.err}


### PR DESCRIPTION
The meta_data.json blob under OpenStack doesn't actually contain all
of the metadata... Fall back to explicitly requesting each attribute.
