### PR TITLE
networkd: Reverse lexicographic order of generated unit files

### DIFF
--- a/network/interface.go
+++ b/network/interface.go
@@ -277,13 +277,17 @@ func markConfigDepths(interfaceMap map[string]networkInterface) {
 		}
 	}
 	for _, iface := range rootInterfaceMap {
-		setDepth(iface, 0)
+		setDepth(iface)
 	}
 }
 
-func setDepth(iface networkInterface, depth int) {
-	iface.setConfigDepth(depth)
+func setDepth(iface networkInterface) int {
+	maxDepth := 0
 	for _, child := range iface.Children() {
-		setDepth(child, depth+1)
+		if depth := setDepth(child); depth > maxDepth {
+			maxDepth = depth
+		}
 	}
+	iface.setConfigDepth(maxDepth)
+	return (maxDepth + 1)
 }

--- a/network/interface_test.go
+++ b/network/interface_test.go
@@ -310,7 +310,7 @@ func TestBuildInterfacesBlindBond(t *testing.T) {
 			name:        "bond0",
 			config:      configMethodManual{},
 			children:    []networkInterface{},
-			configDepth: 1,
+			configDepth: 0,
 		},
 		[]string{"eth0"},
 		map[string]string{},
@@ -320,7 +320,7 @@ func TestBuildInterfacesBlindBond(t *testing.T) {
 			name:        "eth0",
 			config:      configMethodManual{},
 			children:    []networkInterface{bond0},
-			configDepth: 0,
+			configDepth: 1,
 		},
 	}
 	expect := []InterfaceGenerator{bond0, eth0}
@@ -348,7 +348,7 @@ func TestBuildInterfacesBlindVLAN(t *testing.T) {
 			name:        "vlan0",
 			config:      configMethodManual{},
 			children:    []networkInterface{},
-			configDepth: 1,
+			configDepth: 0,
 		},
 		0,
 		"eth0",
@@ -358,7 +358,7 @@ func TestBuildInterfacesBlindVLAN(t *testing.T) {
 			name:        "eth0",
 			config:      configMethodManual{},
 			children:    []networkInterface{vlan0},
-			configDepth: 0,
+			configDepth: 1,
 		},
 	}
 	expect := []InterfaceGenerator{eth0, vlan0}
@@ -423,7 +423,7 @@ func TestBuildInterfaces(t *testing.T) {
 			name:        "vlan1",
 			config:      configMethodManual{},
 			children:    []networkInterface{},
-			configDepth: 2,
+			configDepth: 0,
 		},
 		1,
 		"bond0",
@@ -433,7 +433,7 @@ func TestBuildInterfaces(t *testing.T) {
 			name:        "vlan0",
 			config:      configMethodManual{},
 			children:    []networkInterface{},
-			configDepth: 1,
+			configDepth: 0,
 		},
 		0,
 		"eth0",
@@ -443,7 +443,7 @@ func TestBuildInterfaces(t *testing.T) {
 			name:        "bond1",
 			config:      configMethodManual{},
 			children:    []networkInterface{},
-			configDepth: 2,
+			configDepth: 0,
 		},
 		[]string{"bond0"},
 		map[string]string{},
@@ -466,7 +466,7 @@ func TestBuildInterfaces(t *testing.T) {
 			name:        "eth0",
 			config:      configMethodManual{},
 			children:    []networkInterface{bond0, vlan0},
-			configDepth: 0,
+			configDepth: 2,
 		},
 	}
 	expect := []InterfaceGenerator{eth0, bond0, bond1, vlan0, vlan1}


### PR DESCRIPTION
Assume we have bond0 and eth0. Before this change, eth0 was configured before bond0. Network units for eth0 were referencing bond0 _before_ bond0 had been created. This change reverses the order so that dependent interfaces are created first.
