### PR TITLE
configdrive: Use the EC2 metadata over OpenStack

### DIFF
--- a/datasource/configdrive_test.go
+++ b/datasource/configdrive_test.go
@@ -1,0 +1,114 @@
+package datasource
+
+import (
+	"os"
+	"testing"
+)
+
+type mockFilesystem []string
+
+func (m mockFilesystem) readFile(filename string) ([]byte, error) {
+	for _, file := range m {
+		if file == filename {
+			return []byte(filename), nil
+		}
+	}
+	return nil, os.ErrNotExist
+}
+
+func TestCDFetchMetadata(t *testing.T) {
+	for _, tt := range []struct {
+		root     string
+		filename string
+		files    mockFilesystem
+	}{
+		{
+			"/",
+			"",
+			mockFilesystem{},
+		},
+		{
+			"/",
+			"/ec2/2009-04-04/meta_data.json",
+			mockFilesystem([]string{"/ec2/2009-04-04/meta_data.json"}),
+		},
+		{
+			"/media/configdrive",
+			"/media/configdrive/ec2/2009-04-04/meta_data.json",
+			mockFilesystem([]string{"/media/configdrive/ec2/2009-04-04/meta_data.json"}),
+		},
+	} {
+		cd := configDrive{tt.root, tt.files.readFile}
+		filename, err := cd.FetchMetadata()
+		if err != nil {
+			t.Fatalf("bad error for %q: want %q, got %q", tt, nil, err)
+		}
+		if string(filename) != tt.filename {
+			t.Fatalf("bad path for %q: want %q, got %q", tt, tt.filename, filename)
+		}
+	}
+}
+
+func TestCDFetchUserdata(t *testing.T) {
+	for _, tt := range []struct {
+		root     string
+		filename string
+		files    mockFilesystem
+	}{
+		{
+			"/",
+			"",
+			mockFilesystem{},
+		},
+		{
+			"/",
+			"/ec2/2009-04-04/user_data",
+			mockFilesystem([]string{"/ec2/2009-04-04/user_data"}),
+		},
+		{
+			"/",
+			"/openstack/latest/user_data",
+			mockFilesystem([]string{"/openstack/latest/user_data"}),
+		},
+		{
+			"/",
+			"/ec2/2009-04-04/user_data",
+			mockFilesystem([]string{"/openstack/latest/user_data", "/ec2/2009-04-04/user_data"}),
+		},
+		{
+			"/media/configdrive",
+			"/media/configdrive/ec2/2009-04-04/user_data",
+			mockFilesystem([]string{"/media/configdrive/ec2/2009-04-04/user_data"}),
+		},
+	} {
+		cd := configDrive{tt.root, tt.files.readFile}
+		filename, err := cd.FetchUserdata()
+		if err != nil {
+			t.Fatalf("bad error for %q: want %q, got %q", tt, nil, err)
+		}
+		if string(filename) != tt.filename {
+			t.Fatalf("bad path for %q: want %q, got %q", tt, tt.filename, filename)
+		}
+	}
+}
+
+func TestCDConfigRoot(t *testing.T) {
+	for _, tt := range []struct {
+		root       string
+		configRoot string
+	}{
+		{
+			"/",
+			"/openstack/latest",
+		},
+		{
+			"/media/configdrive",
+			"/media/configdrive/openstack/latest",
+		},
+	} {
+		cd := configDrive{tt.root, nil}
+		if configRoot := cd.ConfigRoot(); configRoot != tt.configRoot {
+			t.Fatalf("bad config root for %q: want %q, got %q", tt, tt.configRoot, configRoot)
+		}
+	}
+}

--- a/datasource/datasource.go
+++ b/datasource/datasource.go
@@ -1,5 +1,10 @@
 package datasource
 
+const (
+	Ec2ApiVersion       = "2009-04-04"
+	OpenstackApiVersion = "2012-08-10"
+)
+
 type Datasource interface {
 	IsAvailable() bool
 	AvailabilityChanges() bool

--- a/datasource/metadata_service.go
+++ b/datasource/metadata_service.go
@@ -22,11 +22,9 @@ import (
 
 const (
 	BaseUrl              = "http://169.254.169.254/"
-	Ec2ApiVersion        = "2009-04-04"
 	Ec2UserdataUrl       = BaseUrl + Ec2ApiVersion + "/user-data"
 	Ec2MetadataUrl       = BaseUrl + Ec2ApiVersion + "/meta-data"
-	OpenstackApiVersion  = "openstack/2012-08-10"
-	OpenstackUserdataUrl = BaseUrl + OpenstackApiVersion + "/user_data"
+	OpenstackUserdataUrl = BaseUrl + "openstack/" + OpenstackApiVersion + "/user_data"
 )
 
 type metadataService struct{}

--- a/datasource/metadata_service_test.go
+++ b/datasource/metadata_service_test.go
@@ -25,7 +25,7 @@ func (t *TestHttpClient) GetRetry(url string) ([]byte, error) {
 	}
 }
 
-func TestFetchAttributes(t *testing.T) {
+func TestMSFetchAttributes(t *testing.T) {
 	for _, s := range []struct {
 		metadata map[string]string
 		err      error
@@ -77,7 +77,7 @@ func TestFetchAttributes(t *testing.T) {
 	}
 }
 
-func TestFetchAttribute(t *testing.T) {
+func TestMSFetchAttribute(t *testing.T) {
 	for _, s := range []struct {
 		metadata map[string]string
 		err      error
@@ -129,7 +129,7 @@ func TestFetchAttribute(t *testing.T) {
 	}
 }
 
-func TestFetchMetadata(t *testing.T) {
+func TestMSFetchMetadata(t *testing.T) {
 	for _, tt := range []struct {
 		metadata map[string]string
 		err      error


### PR DESCRIPTION
Still needs to be properly tested.
