### PR TITLE
docs(quick-start): Clarified use of fields in cloud config

### DIFF
--- a/Documentation/cloud-config.md
+++ b/Documentation/cloud-config.md
@@ -42,8 +42,6 @@ CoreOS tries to conform to each platform's native method to provide user data. E
 The `coreos.etcd.*` parameters will be translated to a partial systemd unit acting as an etcd configuration file.
 If the platform environment supports the templating feature of coreos-cloudinit it is possible to automate etcd configuration with the `$private_ipv4` and `$public_ipv4` fields. For example, the following cloud-config document...
 
-Note: The $private_ipv4 and $public_ipv4 substitution variables referenced in other documents are not supported on PXE or disk installation systems.
-
 ```yaml
 #cloud-config
 
@@ -69,6 +67,8 @@ Environment="ETCD_PEER_ADDR=192.0.2.13:7001"
 
 For more information about the available configuration parameters, see the [etcd documentation][etcd-config].
 Note that hyphens in the coreos.etcd.* keys are mapped to underscores.
+
+_Note: The `$private_ipv4` and `$public_ipv4` substitution variables referenced in other documents are only supported on Amazon EC2, Google Compute Engine, OpenStack, Rackspace, and Vagrant._
 
 [etcd-config]: https://github.com/coreos/etcd/blob/master/Documentation/configuration.md
 


### PR DESCRIPTION
Updated the language to illustrate that fields in a cloud config is not
supported in all environments. This is expressed explicitly in PXE and
install to disk pages. The quick start lacked this information and is
inconsistent.
