### PR TITLE
initialize: use correct heuristic to check if etcdenvironment is set

### DIFF
--- a/initialize/etcd.go
+++ b/initialize/etcd.go
@@ -39,7 +39,7 @@ func (ee EtcdEnvironment) String() (out string) {
 // Units creates a Unit file drop-in for etcd, using any configured
 // options and adding a default MachineID if unset.
 func (ee EtcdEnvironment) Units(root string) ([]system.Unit, error) {
-	if ee == nil {
+	if len(ee) < 1 {
 		return nil, nil
 	}
 

--- a/initialize/etcd_test.go
+++ b/initialize/etcd_test.go
@@ -113,8 +113,19 @@ Environment="ETCD_PEER_BIND_ADDR=127.0.0.1:7002"
 	}
 }
 
-func TestEtcdEnvironmentWrittenToDiskDefaultToMachineID(t *testing.T) {
+func TestEtcdEnvironmentEmptyNoOp(t *testing.T) {
 	ee := EtcdEnvironment{}
+	uu, err := ee.Units("")
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	if len(uu) > 0 {
+		t.Fatalf("Generated etcd units unexpectedly: %v")
+	}
+}
+
+func TestEtcdEnvironmentWrittenToDiskDefaultToMachineID(t *testing.T) {
+	ee := EtcdEnvironment{"foo": "bar"}
 	dir, err := ioutil.TempDir(os.TempDir(), "coreos-cloudinit-")
 	if err != nil {
 		t.Fatalf("Unable to create tempdir: %v", err)
@@ -152,6 +163,7 @@ func TestEtcdEnvironmentWrittenToDiskDefaultToMachineID(t *testing.T) {
 	}
 
 	expect := `[Service]
+Environment="ETCD_FOO=bar"
 Environment="ETCD_NAME=node007"
 `
 	if string(contents) != expect {


### PR DESCRIPTION
In some circumstances (e.g. nova-agent-watcher) cloudconfig files will be
created where the EtcdEnvironment is an empty map, and hence != nil. If this
is the case we should not do anything at all (because the user hasn't
explicitly asked us to configure etcd). This change standardises behaviour
with the check that we already do for FleetEnvironment.

This should fix coreos/bugs#100

/cc @crawford
