### PR TITLE
configdrive: Remove broken support for ec2 metadata

### DIFF
--- a/datasource/configdrive/configdrive.go
+++ b/datasource/configdrive/configdrive.go
@@ -1,13 +1,13 @@
 package configdrive
 
 import (
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path"
 )
 
 const (
-	ec2ApiVersion       = "2009-04-04"
 	openstackApiVersion = "latest"
 )
 
@@ -33,34 +33,28 @@ func (cd *configDrive) ConfigRoot() string {
 	return cd.openstackRoot()
 }
 
-// FetchMetadata attempts to retrieve metadata from ec2/2009-04-04/meta-data.json.
 func (cd *configDrive) FetchMetadata() ([]byte, error) {
-	return cd.tryReadFile(path.Join(cd.ec2Root(), "meta-data.json"))
+	return cd.tryReadFile(path.Join(cd.openstackVersionRoot(), "meta_data.json"))
 }
 
-// FetchUserdata attempts to retrieve the userdata from ec2/2009-04-04/user-data.
-// If no data is found, it will attempt to read from openstack/latest/user_data.
 func (cd *configDrive) FetchUserdata() ([]byte, error) {
-	bytes, err := cd.tryReadFile(path.Join(cd.ec2Root(), "user-data"))
-	if bytes == nil && err == nil {
-		bytes, err = cd.tryReadFile(path.Join(cd.openstackRoot(), "user_data"))
-	}
-	return bytes, err
+	return cd.tryReadFile(path.Join(cd.openstackVersionRoot(), "user_data"))
 }
 
 func (cd *configDrive) Type() string {
 	return "cloud-drive"
 }
 
-func (cd *configDrive) ec2Root() string {
-	return path.Join(cd.root, "ec2", ec2ApiVersion)
+func (cd *configDrive) openstackRoot() string {
+	return path.Join(cd.root, "openstack")
 }
 
-func (cd *configDrive) openstackRoot() string {
-	return path.Join(cd.root, "openstack", openstackApiVersion)
+func (cd *configDrive) openstackVersionRoot() string {
+	return path.Join(cd.openstackRoot(), openstackApiVersion)
 }
 
 func (cd *configDrive) tryReadFile(filename string) ([]byte, error) {
+	fmt.Printf("Attempting to read from %q\n", filename)
 	data, err := cd.readFile(filename)
 	if os.IsNotExist(err) {
 		err = nil

--- a/datasource/configdrive/configdrive_test.go
+++ b/datasource/configdrive/configdrive_test.go
@@ -16,7 +16,7 @@ func (m mockFilesystem) readFile(filename string) ([]byte, error) {
 	return nil, os.ErrNotExist
 }
 
-func TestCDFetchMetadata(t *testing.T) {
+func TestFetchMetadata(t *testing.T) {
 	for _, tt := range []struct {
 		root     string
 		filename string
@@ -29,13 +29,13 @@ func TestCDFetchMetadata(t *testing.T) {
 		},
 		{
 			"/",
-			"/ec2/2009-04-04/meta-data.json",
-			mockFilesystem([]string{"/ec2/2009-04-04/meta-data.json"}),
+			"/openstack/latest/meta_data.json",
+			mockFilesystem([]string{"/openstack/latest/meta_data.json"}),
 		},
 		{
 			"/media/configdrive",
-			"/media/configdrive/ec2/2009-04-04/meta-data.json",
-			mockFilesystem([]string{"/media/configdrive/ec2/2009-04-04/meta-data.json"}),
+			"/media/configdrive/openstack/latest/meta_data.json",
+			mockFilesystem([]string{"/media/configdrive/openstack/latest/meta_data.json"}),
 		},
 	} {
 		cd := configDrive{tt.root, tt.files.readFile}
@@ -49,7 +49,7 @@ func TestCDFetchMetadata(t *testing.T) {
 	}
 }
 
-func TestCDFetchUserdata(t *testing.T) {
+func TestFetchUserdata(t *testing.T) {
 	for _, tt := range []struct {
 		root     string
 		filename string
@@ -62,23 +62,13 @@ func TestCDFetchUserdata(t *testing.T) {
 		},
 		{
 			"/",
-			"/ec2/2009-04-04/user-data",
-			mockFilesystem([]string{"/ec2/2009-04-04/user-data"}),
-		},
-		{
-			"/",
 			"/openstack/latest/user_data",
 			mockFilesystem([]string{"/openstack/latest/user_data"}),
 		},
 		{
-			"/",
-			"/ec2/2009-04-04/user-data",
-			mockFilesystem([]string{"/openstack/latest/user_data", "/ec2/2009-04-04/user-data"}),
-		},
-		{
 			"/media/configdrive",
-			"/media/configdrive/ec2/2009-04-04/user-data",
-			mockFilesystem([]string{"/media/configdrive/ec2/2009-04-04/user-data"}),
+			"/media/configdrive/openstack/latest/user_data",
+			mockFilesystem([]string{"/media/configdrive/openstack/latest/user_data"}),
 		},
 	} {
 		cd := configDrive{tt.root, tt.files.readFile}
@@ -92,18 +82,18 @@ func TestCDFetchUserdata(t *testing.T) {
 	}
 }
 
-func TestCDConfigRoot(t *testing.T) {
+func TestConfigRoot(t *testing.T) {
 	for _, tt := range []struct {
 		root       string
 		configRoot string
 	}{
 		{
 			"/",
-			"/openstack/latest",
+			"/openstack",
 		},
 		{
 			"/media/configdrive",
-			"/media/configdrive/openstack/latest",
+			"/media/configdrive/openstack",
 		},
 	} {
 		cd := configDrive{tt.root, nil}

--- a/initialize/config.go
+++ b/initialize/config.go
@@ -258,7 +258,9 @@ func Apply(cfg CloudConfig, env *Environment) error {
 	}
 
 	if env.NetconfType() != "" {
-		netconfBytes, err := ioutil.ReadFile(path.Join(env.ConfigRoot(), cfg.NetworkConfigPath))
+		filename := path.Join(env.ConfigRoot(), cfg.NetworkConfigPath)
+		log.Printf("Attempting to read config from %q\n", filename)
+		netconfBytes, err := ioutil.ReadFile(filename)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
As it turns out, certain metadata is only present in the ec2 flavor
of metadata (e.g. public_ipv4) and other data is only present in
the openstack flavor (e.g. network_config). For now, just read the
openstack metadata.
