### PR TITLE
configdrive: don't fail if no network config was provided

### DIFF
--- a/coreos-cloudinit.go
+++ b/coreos-cloudinit.go
@@ -163,7 +163,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	if ccm != nil {
+	if ccm != nil && flags.convertNetconf != "" {
 		fmt.Printf("Fetching network config from datasource of type %q\n", ds.Type())
 		netconfBytes, err := ds.FetchNetworkConfig(ccm.NetworkConfigPath)
 		if err != nil {

--- a/datasource/configdrive/configdrive.go
+++ b/datasource/configdrive/configdrive.go
@@ -42,6 +42,9 @@ func (cd *configDrive) FetchUserdata() ([]byte, error) {
 }
 
 func (cd *configDrive) FetchNetworkConfig(filename string) ([]byte, error) {
+	if filename == "" {
+		return []byte{}, nil
+	}
 	return cd.tryReadFile(path.Join(cd.openstackRoot(), filename))
 }
 


### PR DESCRIPTION
This fixes the previous patch, which caused DigitalOcean droplets to ignore their network config. This approach makes more sense anyway. It should be up to the datasource to determine what to do with an empty network config filename.
