### PR TITLE
network: add support for CIDR addresses Debian routes

### DIFF
--- a/network/stanza.go
+++ b/network/stanza.go
@@ -236,7 +236,11 @@ func parseInterfaceStanza(attributes []string, options []string) (*stanzaInterfa
 				for i, field := range fields[:len(fields)-1] {
 					switch field {
 					case "-net":
-						route.destination.IP = net.ParseIP(fields[i+1])
+						if _, dst, err := net.ParseCIDR(fields[i+1]); err == nil {
+							route.destination = *dst
+						} else {
+							route.destination.IP = net.ParseIP(fields[i+1])
+						}
 					case "netmask":
 						route.destination.Mask = net.IPMask(net.ParseIP(fields[i+1]).To4())
 					case "gw":


### PR DESCRIPTION
OnMetal is changing their template from:
`route add -net 1.2.3.0 netmask 255.255.255.0 gw 10.1.2.1 || true`
to:
`route add -net 1.2.3.0/24 gw 10.1.2.1 || true`
