### PR TITLE
AWS: Eucalyptus 4.x compatibility fix

### DIFF
--- a/datasource/metadata/ec2/metadata.go
+++ b/datasource/metadata/ec2/metadata.go
@@ -13,9 +13,9 @@ import (
 
 const (
 	DefaultAddress = "http://169.254.169.254/"
-	apiVersion     = "2009-04-04"
-	userdataPath   = apiVersion + "/user-data"
-	metadataPath   = apiVersion + "/meta-data"
+	apiVersion     = "2009-04-04/"
+	userdataPath   = apiVersion + "user-data"
+	metadataPath   = apiVersion + "meta-data"
 )
 
 type metadataService struct {


### PR DESCRIPTION
For Eucalyptus 4.0.1 requesting metadata seem to work differently as with EC2.

In Euca:

> curl http://169.254.169.254/2009-04-04
> <?xml version="1.0"?><Response><Errors><Error><Code>404 Not Found</Code><Message>unknown</Message></Error></Errors><RequestID>unknown</RequestID></Response>
> 
> curl http://169.254.169.254/2009-04-04/
> dynamic
> meta-data
> user-data

In AWS EC2

> curl http://169.254.169.254/2009-04-04
> "" (zero bytes)
> 
> curl http://169.254.169.254/2009-04-04/
> dynamic
> meta-data
> user-data

As the isAvailable() function in metadata.go tests only for error code it fails in Euca.
