### PR TITLE
config/update: add "off" as a valid strategy

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -513,6 +513,7 @@ func TestNormalizeKeys(t *testing.T) {
 		{"a:\n  b:\n  - key-name: the-value\n", "a:\n  b:\n  - key_name: the-value\n"},
 
 		{"coreos:\n  update:\n    reboot-strategy: off\n", "coreos:\n  update:\n    reboot_strategy: false\n"},
+		{"coreos:\n  update:\n    reboot-strategy: 'off'\n", "coreos:\n  update:\n    reboot_strategy: \"off\"\n"},
 	} {
 		out, err := normalizeConfig(tt.in)
 		if err != nil {

--- a/config/update.go
+++ b/config/update.go
@@ -17,7 +17,7 @@
 package config
 
 type Update struct {
-	RebootStrategy string `yaml:"reboot_strategy" env:"REBOOT_STRATEGY" valid:"best-effort,etcd-lock,reboot,false"`
+	RebootStrategy string `yaml:"reboot_strategy" env:"REBOOT_STRATEGY" valid:"best-effort,etcd-lock,reboot,off,false"`
 	Group          string `yaml:"group"           env:"GROUP"`
 	Server         string `yaml:"server"          env:"SERVER"`
 }

--- a/system/update.go
+++ b/system/update.go
@@ -126,7 +126,7 @@ func (uc Update) Units() []Unit {
 			Runtime: true,
 		}}
 
-		if uc.Update.RebootStrategy == "false" {
+		if uc.Update.RebootStrategy == "false" || uc.Update.RebootStrategy == "off" {
 			ls.Command = "stop"
 			ls.Mask = true
 		}

--- a/system/update_test.go
+++ b/system/update_test.go
@@ -80,6 +80,15 @@ func TestUpdateUnits(t *testing.T) {
 				Mask:    true,
 			}}},
 		},
+		{
+			config: config.Update{RebootStrategy: "off"},
+			units: []Unit{{config.Unit{
+				Name:    "locksmithd.service",
+				Command: "stop",
+				Runtime: true,
+				Mask:    true,
+			}}},
+		},
 	} {
 		units := Update{Update: tt.config, ReadConfig: testReadConfig("")}.Units()
 		if !reflect.DeepEqual(tt.units, units) {
@@ -100,7 +109,7 @@ func TestUpdateFile(t *testing.T) {
 		},
 		{
 			config: config.Update{RebootStrategy: "wizzlewazzle"},
-			err:    &config.ErrorValid{Value: "wizzlewazzle", Field: "RebootStrategy", Valid: []string{"best-effort", "etcd-lock", "reboot", "false"}},
+			err:    &config.ErrorValid{Value: "wizzlewazzle", Field: "RebootStrategy", Valid: []string{"best-effort", "etcd-lock", "reboot", "off", "false"}},
 		},
 		{
 			config: config.Update{Group: "master", Server: "http://foo.com"},
@@ -138,6 +147,14 @@ func TestUpdateFile(t *testing.T) {
 			config: config.Update{RebootStrategy: "false"},
 			file: &File{config.File{
 				Content:            "REBOOT_STRATEGY=false\n",
+				Path:               "etc/coreos/update.conf",
+				RawFilePermissions: "0644",
+			}},
+		},
+		{
+			config: config.Update{RebootStrategy: "off"},
+			file: &File{config.File{
+				Content:            "REBOOT_STRATEGY=off\n",
 				Path:               "etc/coreos/update.conf",
 				RawFilePermissions: "0644",
 			}},


### PR DESCRIPTION
It was assumed that the user would specify the reboot strategy as an
unquoted value. In the case that they turn off updates, `off` is
interpreted as a boolean and the normalization pass converts that to
`false`. In the event that the user uses `"off"`, it's interpreted as a
string and not modified.
