### PR TITLE
the flannel service is called flanneld

### DIFF
--- a/system/flannel.go
+++ b/system/flannel.go
@@ -13,5 +13,5 @@ type Flannel struct {
 // Units generates a Unit file drop-in for flannel, if any flannel options were
 // configured in cloud-config
 func (fl Flannel) Units() []Unit {
-	return dropinFromConfig(fl.Flannel, "flannel.service")
+	return dropinFromConfig(fl.Flannel, "flanneld.service")
 }

--- a/system/flannel_test.go
+++ b/system/flannel_test.go
@@ -22,7 +22,7 @@ func TestFlannelUnits(t *testing.T) {
 				EtcdPrefix:   "/coreos.com/network/tenant1",
 			},
 			[]Unit{{config.Unit{
-				Name: "flannel.service",
+				Name: "flanneld.service",
 				Content: `[Service]
 Environment="FLANNELD_ETCD_ENDPOINT=http://12.34.56.78:4001"
 Environment="FLANNELD_ETCD_PREFIX=/coreos.com/network/tenant1"


### PR DESCRIPTION
The CoreOS unit for flannel is called flanneld, so no configuration is imported from the user's cloud init file when starting flannel
