### PR TITLE
Create an environment file for flannel

### DIFF
--- a/initialize/config.go
+++ b/initialize/config.go
@@ -113,6 +113,7 @@ func Apply(cfg config.CloudConfig, env *Environment) error {
 		system.OEM{OEM: cfg.Coreos.OEM},
 		system.Update{Update: cfg.Coreos.Update, ReadConfig: system.DefaultReadConfig},
 		system.EtcHosts{EtcHosts: cfg.ManageEtcHosts},
+		system.Flannel{Flannel: cfg.Coreos.Flannel},
 	} {
 		f, err := ccf.File()
 		if err != nil {
@@ -132,7 +133,6 @@ func Apply(cfg config.CloudConfig, env *Environment) error {
 		system.Etcd{Etcd: cfg.Coreos.Etcd},
 		system.Fleet{Fleet: cfg.Coreos.Fleet},
 		system.Locksmith{Locksmith: cfg.Coreos.Locksmith},
-		system.Flannel{Flannel: cfg.Coreos.Flannel},
 		system.Update{Update: cfg.Coreos.Update, ReadConfig: system.DefaultReadConfig},
 	} {
 		units = append(units, ccu.Units()...)

--- a/system/flannel_test.go
+++ b/system/flannel_test.go
@@ -7,40 +7,56 @@ import (
 	"github.com/coreos/coreos-cloudinit/config"
 )
 
-func TestFlannelUnits(t *testing.T) {
+func TestFlannelEnvVars(t *testing.T) {
 	for _, tt := range []struct {
-		config config.Flannel
-		units  []Unit
+		config   config.Flannel
+		contents string
 	}{
 		{
 			config.Flannel{},
-			[]Unit{{config.Unit{
-				Name:    "flanneld.service",
-				Runtime: true,
-				DropIns: []config.UnitDropIn{{Name: "20-cloudinit.conf"}},
-			}}},
+			"",
 		},
 		{
 			config.Flannel{
 				EtcdEndpoint: "http://12.34.56.78:4001",
 				EtcdPrefix:   "/coreos.com/network/tenant1",
 			},
-			[]Unit{{config.Unit{
-				Name:    "flanneld.service",
-				Runtime: true,
-				DropIns: []config.UnitDropIn{{
-					Name: "20-cloudinit.conf",
-					Content: `[Service]
-Environment="FLANNELD_ETCD_ENDPOINT=http://12.34.56.78:4001"
-Environment="FLANNELD_ETCD_PREFIX=/coreos.com/network/tenant1"
-`,
-				}},
-			}}},
+			`FLANNELD_ETCD_ENDPOINT=http://12.34.56.78:4001
+FLANNELD_ETCD_PREFIX=/coreos.com/network/tenant1`,
 		},
 	} {
-		units := Flannel{tt.config}.Units()
-		if !reflect.DeepEqual(units, tt.units) {
-			t.Errorf("bad units (%q): want %v, got %v", tt.config, tt.units, units)
+		out := Flannel{tt.config}.envVars()
+		if out != tt.contents {
+			t.Errorf("bad contents (%+v): want %q, got %q", tt, tt.contents, out)
+		}
+	}
+}
+
+func TestFlannelFile(t *testing.T) {
+	for _, tt := range []struct {
+		config config.Flannel
+		file   *File
+	}{
+		{
+			config.Flannel{},
+			nil,
+		},
+		{
+			config.Flannel{
+				EtcdEndpoint: "http://12.34.56.78:4001",
+				EtcdPrefix:   "/coreos.com/network/tenant1",
+			},
+			&File{config.File{
+				Path:               "run/flannel/options.env",
+				RawFilePermissions: "0644",
+				Content: `FLANNELD_ETCD_ENDPOINT=http://12.34.56.78:4001
+FLANNELD_ETCD_PREFIX=/coreos.com/network/tenant1`,
+			}},
+		},
+	} {
+		file, _ := Flannel{tt.config}.File()
+		if !reflect.DeepEqual(tt.file, file) {
+			t.Errorf("bad units (%q): want %#v, got %#v", tt.config, tt.file, file)
 		}
 	}
 }


### PR DESCRIPTION
Rather than using a systemd overlay, allow docker to load the
environment file. This is due to coreos/coreos-overlay#1002

(cc @eyakubovich)
