### PR TITLE
network: write network units with user units

### DIFF
--- a/initialize/config.go
+++ b/initialize/config.go
@@ -169,16 +169,13 @@ func Apply(cfg config.CloudConfig, env *Environment) error {
 		case "digitalocean":
 			interfaces, err = network.ProcessDigitalOceanNetconf(cfg.NetworkConfig)
 		default:
-			return fmt.Errorf("Unsupported network config format %q", env.NetconfType())
+			err = fmt.Errorf("Unsupported network config format %q", env.NetconfType())
 		}
-
 		if err != nil {
 			return err
 		}
 
-		if err := system.WriteNetworkdConfigs(interfaces); err != nil {
-			return err
-		}
+		units = append(units, createNetworkingUnits(interfaces)...)
 		if err := system.RestartNetwork(interfaces); err != nil {
 			return err
 		}
@@ -186,7 +183,25 @@ func Apply(cfg config.CloudConfig, env *Environment) error {
 
 	um := system.NewUnitManager(env.Root())
 	return processUnits(units, env.Root(), um)
+}
 
+func createNetworkingUnits(interfaces []network.InterfaceGenerator) (units []system.Unit) {
+	appendNewUnit := func(units []system.Unit, name, content string) []system.Unit {
+		if content == "" {
+			return units
+		}
+		return append(units, system.Unit{Unit: config.Unit{
+			Name:    name,
+			Runtime: true,
+			Content: content,
+		}})
+	}
+	for _, i := range interfaces {
+		units = appendNewUnit(units, fmt.Sprintf("%s.netdev", i.Filename()), i.Netdev())
+		units = appendNewUnit(units, fmt.Sprintf("%s.link", i.Filename()), i.Link())
+		units = appendNewUnit(units, fmt.Sprintf("%s.network", i.Filename()), i.Network())
+	}
+	return units
 }
 
 // processUnits takes a set of Units and applies them to the given root using

--- a/system/networkd.go
+++ b/system/networkd.go
@@ -29,10 +29,6 @@ import (
 	"github.com/coreos/coreos-cloudinit/Godeps/_workspace/src/github.com/dotcloud/docker/pkg/netlink"
 )
 
-const (
-	runtimeNetworkPath = "/run/systemd/network"
-)
-
 func RestartNetwork(interfaces []network.InterfaceGenerator) (err error) {
 	defer func() {
 		if e := restartNetworkd(); e != nil {
@@ -98,32 +94,5 @@ func restartNetworkd() error {
 	log.Printf("Restarting networkd.service\n")
 	networkd := Unit{config.Unit{Name: "systemd-networkd.service"}}
 	_, err := NewUnitManager("").RunUnitCommand(networkd, "restart")
-	return err
-}
-
-func WriteNetworkdConfigs(interfaces []network.InterfaceGenerator) error {
-	for _, iface := range interfaces {
-		filename := fmt.Sprintf("%s.netdev", iface.Filename())
-		if err := writeConfig(filename, iface.Netdev()); err != nil {
-			return err
-		}
-		filename = fmt.Sprintf("%s.link", iface.Filename())
-		if err := writeConfig(filename, iface.Link()); err != nil {
-			return err
-		}
-		filename = fmt.Sprintf("%s.network", iface.Filename())
-		if err := writeConfig(filename, iface.Network()); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func writeConfig(filename string, content string) error {
-	if content == "" {
-		return nil
-	}
-	log.Printf("Writing networkd unit %q\n", filename)
-	_, err := WriteFile(&File{config.File{Content: content, Path: filename}}, runtimeNetworkPath)
 	return err
 }


### PR DESCRIPTION
This allows us to test the network unit generation as well as removing
some special-cased code.
