### PR TITLE
config: rename flannel's interface to iface in YAML

### DIFF
--- a/config/flannel.go
+++ b/config/flannel.go
@@ -5,5 +5,5 @@ type Flannel struct {
 	EtcdPrefix   string `yaml:"etcd_prefix"   env:"FLANNELD_ETCD_PREFIX"`
 	IPMasq       string `yaml:"ip_masq"       env:"FLANNELD_IP_MASQ"`
 	SubnetFile   string `yaml:"subnet_file"   env:"FLANNELD_SUBNET_FILE"`
-	Iface        string `yaml:"interface"     env:"FLANNELD_IFACE"`
+	Iface        string `yaml:"iface"         env:"FLANNELD_IFACE"`
 }


### PR DESCRIPTION
The env var is FLANNELD_IFACE and YAML keys should match
to be consistent.

Fixes #297