### PR TITLE
configdrive: check metadata length before parsing

### DIFF
--- a/datasource/configdrive/configdrive.go
+++ b/datasource/configdrive/configdrive.go
@@ -60,7 +60,7 @@ func (cd *configDrive) FetchMetadata() (metadata datasource.Metadata, err error)
 		} `json:"network_config"`
 	}
 
-	if data, err = cd.tryReadFile(path.Join(cd.openstackVersionRoot(), "meta_data.json")); err != nil {
+	if data, err = cd.tryReadFile(path.Join(cd.openstackVersionRoot(), "meta_data.json")); err != nil || len(data) == 0 {
 		return
 	}
 	if err = json.Unmarshal([]byte(data), &m); err != nil {

--- a/datasource/configdrive/configdrive_test.go
+++ b/datasource/configdrive/configdrive_test.go
@@ -31,6 +31,10 @@ func TestFetchMetadata(t *testing.T) {
 	}{
 		{
 			root:  "/",
+			files: test.MockFilesystem{"/openstack/latest/meta_data.json": ""},
+		},
+		{
+			root:  "/",
 			files: test.MockFilesystem{"/openstack/latest/meta_data.json": `{"ignore": "me"}`},
 		},
 		{


### PR DESCRIPTION
This was lost in some of the recent refactoring.