### PR TITLE
Make sure public ssh key is not empty from CloudSigma's server context

### DIFF
--- a/datasource/metadata/cloudsigma/server_context.go
+++ b/datasource/metadata/cloudsigma/server_context.go
@@ -108,7 +108,7 @@ func (scs *serverContextService) FetchMetadata() (metadata datasource.Metadata, 
 	}
 
 	metadata.SSHPublicKeys = map[string]string{}
-	if key, ok := inputMetadata.Meta["ssh_public_key"]; ok {
+	if key, _ := inputMetadata.Meta["ssh_public_key"]; len(key) > 0 {
 		splitted := strings.Split(key, " ")
 		metadata.SSHPublicKeys[splitted[len(splitted)-1]] = key
 	}

--- a/datasource/metadata/cloudsigma/server_context.go
+++ b/datasource/metadata/cloudsigma/server_context.go
@@ -108,6 +108,8 @@ func (scs *serverContextService) FetchMetadata() (metadata datasource.Metadata, 
 	}
 
 	metadata.SSHPublicKeys = map[string]string{}
+	// CloudSigma uses an empty string, rather than no string,
+	// to represent the lack of a SSH key
 	if key, _ := inputMetadata.Meta["ssh_public_key"]; len(key) > 0 {
 		splitted := strings.Split(key, " ")
 		metadata.SSHPublicKeys[splitted[len(splitted)-1]] = key

--- a/datasource/metadata/cloudsigma/server_context_test.go
+++ b/datasource/metadata/cloudsigma/server_context_test.go
@@ -43,6 +43,27 @@ func (f *fakeCepgoClient) FetchRaw(key string) ([]byte, error) {
 	return f.raw, f.err
 }
 
+func TestServerContextWithEmptyPublicSSHKey(t *testing.T) {
+	client := new(fakeCepgoClient)
+	scs := NewServerContextService()
+	scs.client = client
+	client.raw = []byte(`{
+		"meta": {
+			"base64_fields": "cloudinit-user-data",
+			"cloudinit-user-data": "I2Nsb3VkLWNvbmZpZwoKaG9zdG5hbWU6IGNvcmVvczE=",
+			"ssh_public_key": ""
+		}
+	}`)
+	metadata, err := scs.FetchMetadata()
+	if err != nil {
+		t.Error(err.Error())
+	}
+
+	if len(metadata.SSHPublicKeys) != 0 {
+		t.Error("There should be no Public SSH Keys provided")
+	}
+}
+
 func TestServerContextFetchMetadata(t *testing.T) {
 	client := new(fakeCepgoClient)
 	scs := NewServerContextService()


### PR DESCRIPTION
Even when public ssh key is not set by the user, CloudSigma's server
context has a key `meta.ssh_public_key` which is just an empty string.
So instead of just relying on the "comma ok" idiom I make sure the value
is not an empty string.