### PR TITLE
config/system: add shell user attribute

### DIFF
--- a/Documentation/cloud-config.md
+++ b/Documentation/cloud-config.md
@@ -299,6 +299,7 @@ All but the `passwd` and `ssh-authorized-keys` fields will be ignored if the use
 - **coreos-ssh-import-url**: Authorize SSH keys imported from a url endpoint.
 - **system**: Create the user as a system user. No home directory will be created.
 - **no-log-init**: Boolean. Skip initialization of lastlog and faillog databases.
+- **shell**: User's login shell.
 
 The following fields are not yet implemented:
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -374,6 +374,7 @@ users:
     no_user_group: true
     system: y
     no_log_init: True
+    shell: /bin/sh
 `
 	cfg, err := NewCloudConfig(contents)
 	if err != nil {
@@ -440,6 +441,10 @@ users:
 
 	if !user.NoLogInit {
 		t.Errorf("Failed to parse no_log_init field")
+	}
+
+	if user.Shell != "/bin/sh" {
+		t.Errorf("Failed to parse shell field, got %q", user.Shell)
 	}
 }
 

--- a/config/user.go
+++ b/config/user.go
@@ -29,4 +29,5 @@ type User struct {
 	NoUserGroup          bool     `yaml:"no_user_group"`
 	System               bool     `yaml:"system"`
 	NoLogInit            bool     `yaml:"no_log_init"`
+	Shell                string   `yaml:"shell"`
 }

--- a/system/user.go
+++ b/system/user.go
@@ -72,6 +72,10 @@ func CreateUser(u *config.User) error {
 		args = append(args, "--no-log-init")
 	}
 
+	if u.Shell != "" {
+		args = append(args, "--shell", u.Shell)
+	}
+
 	args = append(args, u.Name)
 
 	output, err := exec.Command("useradd", args...).CombinedOutput()


### PR DESCRIPTION
This adds support for specifying the login shell of created users.