### PR TITLE
config: add support for etcd2

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -37,6 +37,7 @@ type CloudConfig struct {
 
 type CoreOS struct {
 	Etcd      Etcd      `yaml:"etcd"`
+	Etcd2     Etcd2     `yaml:"etcd2"`
 	Flannel   Flannel   `yaml:"flannel"`
 	Fleet     Fleet     `yaml:"fleet"`
 	Locksmith Locksmith `yaml:"locksmith"`

--- a/config/etcd.go
+++ b/config/etcd.go
@@ -16,7 +16,7 @@ package config
 
 type Etcd struct {
 	Addr                     string  `yaml:"addr"                          env:"ETCD_ADDR"`
-	AdvertiseClientURLs      string  `yaml:"advertise_client_urls"         env:"ETCD_ADVERTISE_CLIENT_URLS"`
+	AdvertiseClientURLs      string  `yaml:"advertise_client_urls"         env:"ETCD_ADVERTISE_CLIENT_URLS"       deprecated:"etcd2 options no longer work for etcd"`
 	BindAddr                 string  `yaml:"bind_addr"                     env:"ETCD_BIND_ADDR"`
 	CAFile                   string  `yaml:"ca_file"                       env:"ETCD_CA_FILE"`
 	CertFile                 string  `yaml:"cert_file"                     env:"ETCD_CERT_FILE"`
@@ -26,26 +26,26 @@ type Etcd struct {
 	CorsOrigins              string  `yaml:"cors"                          env:"ETCD_CORS"`
 	DataDir                  string  `yaml:"data_dir"                      env:"ETCD_DATA_DIR"`
 	Discovery                string  `yaml:"discovery"                     env:"ETCD_DISCOVERY"`
-	DiscoveryFallback        string  `yaml:"discovery_fallback"            env:"ETCD_DISCOVERY_FALLBACK"`
-	DiscoverySRV             string  `yaml:"discovery_srv"                 env:"ETCD_DISCOVERY_SRV"`
-	DiscoveryProxy           string  `yaml:"discovery_proxy"               env:"ETCD_DISCOVERY_PROXY"`
-	ElectionTimeout          int     `yaml:"election_timeout"              env:"ETCD_ELECTION_TIMEOUT"`
-	ForceNewCluster          bool    `yaml:"force_new_cluster"             env:"ETCD_FORCE_NEW_CLUSTER"`
+	DiscoveryFallback        string  `yaml:"discovery_fallback"            env:"ETCD_DISCOVERY_FALLBACK"          deprecated:"etcd2 options no longer work for etcd"`
+	DiscoverySRV             string  `yaml:"discovery_srv"                 env:"ETCD_DISCOVERY_SRV"               deprecated:"etcd2 options no longer work for etcd"`
+	DiscoveryProxy           string  `yaml:"discovery_proxy"               env:"ETCD_DISCOVERY_PROXY"             deprecated:"etcd2 options no longer work for etcd"`
+	ElectionTimeout          int     `yaml:"election_timeout"              env:"ETCD_ELECTION_TIMEOUT"            deprecated:"etcd2 options no longer work for etcd"`
+	ForceNewCluster          bool    `yaml:"force_new_cluster"             env:"ETCD_FORCE_NEW_CLUSTER"           deprecated:"etcd2 options no longer work for etcd"`
 	GraphiteHost             string  `yaml:"graphite_host"                 env:"ETCD_GRAPHITE_HOST"`
-	HeartbeatInterval        int     `yaml:"heartbeat_interval"            env:"ETCD_HEARTBEAT_INTERVAL"`
+	HeartbeatInterval        int     `yaml:"heartbeat_interval"            env:"ETCD_HEARTBEAT_INTERVAL"          deprecated:"etcd2 options no longer work for etcd"`
 	HTTPReadTimeout          float64 `yaml:"http_read_timeout"             env:"ETCD_HTTP_READ_TIMEOUT"`
 	HTTPWriteTimeout         float64 `yaml:"http_write_timeout"            env:"ETCD_HTTP_WRITE_TIMEOUT"`
-	InitialAdvertisePeerURLs string  `yaml:"initial_advertise_peer_urls"   env:"ETCD_INITIAL_ADVERTISE_PEER_URLS"`
-	InitialCluster           string  `yaml:"initial_cluster"               env:"ETCD_INITIAL_CLUSTER"`
-	InitialClusterState      string  `yaml:"initial_cluster_state"         env:"ETCD_INITIAL_CLUSTER_STATE"`
-	InitialClusterToken      string  `yaml:"initial_cluster_token"         env:"ETCD_INITIAL_CLUSTER_TOKEN"`
+	InitialAdvertisePeerURLs string  `yaml:"initial_advertise_peer_urls"   env:"ETCD_INITIAL_ADVERTISE_PEER_URLS" deprecated:"etcd2 options no longer work for etcd"`
+	InitialCluster           string  `yaml:"initial_cluster"               env:"ETCD_INITIAL_CLUSTER"             deprecated:"etcd2 options no longer work for etcd"`
+	InitialClusterState      string  `yaml:"initial_cluster_state"         env:"ETCD_INITIAL_CLUSTER_STATE"       deprecated:"etcd2 options no longer work for etcd"`
+	InitialClusterToken      string  `yaml:"initial_cluster_token"         env:"ETCD_INITIAL_CLUSTER_TOKEN"       deprecated:"etcd2 options no longer work for etcd"`
 	KeyFile                  string  `yaml:"key_file"                      env:"ETCD_KEY_FILE"`
-	ListenClientURLs         string  `yaml:"listen_client_urls"            env:"ETCD_LISTEN_CLIENT_URLS"`
-	ListenPeerURLs           string  `yaml:"listen_peer_urls"              env:"ETCD_LISTEN_PEER_URLS"`
+	ListenClientURLs         string  `yaml:"listen_client_urls"            env:"ETCD_LISTEN_CLIENT_URLS"          deprecated:"etcd2 options no longer work for etcd"`
+	ListenPeerURLs           string  `yaml:"listen_peer_urls"              env:"ETCD_LISTEN_PEER_URLS"            deprecated:"etcd2 options no longer work for etcd"`
 	MaxResultBuffer          int     `yaml:"max_result_buffer"             env:"ETCD_MAX_RESULT_BUFFER"`
 	MaxRetryAttempts         int     `yaml:"max_retry_attempts"            env:"ETCD_MAX_RETRY_ATTEMPTS"`
-	MaxSnapshots             int     `yaml:"max_snapshots"                 env:"ETCD_MAX_SNAPSHOTS"`
-	MaxWALs                  int     `yaml:"max_wals"                      env:"ETCD_MAX_WALS"`
+	MaxSnapshots             int     `yaml:"max_snapshots"                 env:"ETCD_MAX_SNAPSHOTS"               deprecated:"etcd2 options no longer work for etcd"`
+	MaxWALs                  int     `yaml:"max_wals"                      env:"ETCD_MAX_WALS"                    deprecated:"etcd2 options no longer work for etcd"`
 	Name                     string  `yaml:"name"                          env:"ETCD_NAME"`
 	PeerAddr                 string  `yaml:"peer_addr"                     env:"ETCD_PEER_ADDR"`
 	PeerBindAddr             string  `yaml:"peer_bind_addr"                env:"ETCD_PEER_BIND_ADDR"`
@@ -56,7 +56,7 @@ type Etcd struct {
 	PeerKeyFile              string  `yaml:"peer_key_file"                 env:"ETCD_PEER_KEY_FILE"`
 	Peers                    string  `yaml:"peers"                         env:"ETCD_PEERS"`
 	PeersFile                string  `yaml:"peers_file"                    env:"ETCD_PEERS_FILE"`
-	Proxy                    string  `yaml:"proxy"                         env:"ETCD_PROXY"`
+	Proxy                    string  `yaml:"proxy"                         env:"ETCD_PROXY"                       deprecated:"etcd2 options no longer work for etcd"`
 	RetryInterval            float64 `yaml:"retry_interval"                env:"ETCD_RETRY_INTERVAL"`
 	Snapshot                 bool    `yaml:"snapshot"                      env:"ETCD_SNAPSHOT"`
 	SnapshotCount            int     `yaml:"snapshot_count"                env:"ETCD_SNAPSHOTCOUNT"`

--- a/config/etcd2.go
+++ b/config/etcd2.go
@@ -1,0 +1,44 @@
+// Copyright 2015 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+type Etcd2 struct {
+	AdvertiseClientURLs      string `yaml:"advertise_client_urls"         env:"ETCD_ADVERTISE_CLIENT_URLS"`
+	CAFile                   string `yaml:"ca_file"                       env:"ETCD_CA_FILE"`
+	CertFile                 string `yaml:"cert_file"                     env:"ETCD_CERT_FILE"`
+	CorsOrigins              string `yaml:"cors"                          env:"ETCD_CORS"`
+	DataDir                  string `yaml:"data_dir"                      env:"ETCD_DATA_DIR"`
+	Discovery                string `yaml:"discovery"                     env:"ETCD_DISCOVERY"`
+	DiscoveryFallback        string `yaml:"discovery_fallback"            env:"ETCD_DISCOVERY_FALLBACK"`
+	DiscoverySRV             string `yaml:"discovery_srv"                 env:"ETCD_DISCOVERY_SRV"`
+	DiscoveryProxy           string `yaml:"discovery_proxy"               env:"ETCD_DISCOVERY_PROXY"`
+	ElectionTimeout          int    `yaml:"election_timeout"              env:"ETCD_ELECTION_TIMEOUT"`
+	HeartbeatInterval        int    `yaml:"heartbeat_interval"            env:"ETCD_HEARTBEAT_INTERVAL"`
+	InitialAdvertisePeerURLs string `yaml:"initial_advertise_peer_urls"   env:"ETCD_INITIAL_ADVERTISE_PEER_URLS"`
+	InitialCluster           string `yaml:"initial_cluster"               env:"ETCD_INITIAL_CLUSTER"`
+	InitialClusterState      string `yaml:"initial_cluster_state"         env:"ETCD_INITIAL_CLUSTER_STATE"`
+	InitialClusterToken      string `yaml:"initial_cluster_token"         env:"ETCD_INITIAL_CLUSTER_TOKEN"`
+	KeyFile                  string `yaml:"key_file"                      env:"ETCD_KEY_FILE"`
+	ListenClientURLs         string `yaml:"listen_client_urls"            env:"ETCD_LISTEN_CLIENT_URLS"`
+	ListenPeerURLs           string `yaml:"listen_peer_urls"              env:"ETCD_LISTEN_PEER_URLS"`
+	MaxSnapshots             int    `yaml:"max_snapshots"                 env:"ETCD_MAX_SNAPSHOTS"`
+	MaxWALs                  int    `yaml:"max_wals"                      env:"ETCD_MAX_WALS"`
+	Name                     string `yaml:"name"                          env:"ETCD_NAME"`
+	PeerCAFile               string `yaml:"peer_ca_file"                  env:"ETCD_PEER_CA_FILE"`
+	PeerCertFile             string `yaml:"peer_cert_file"                env:"ETCD_PEER_CERT_FILE"`
+	PeerKeyFile              string `yaml:"peer_key_file"                 env:"ETCD_PEER_KEY_FILE"`
+	Proxy                    string `yaml:"proxy"                         env:"ETCD_PROXY"`
+	SnapshotCount            int    `yaml:"snapshot_count"                env:"ETCD_SNAPSHOTCOUNT"`
+}

--- a/config/validate/rules.go
+++ b/config/validate/rules.go
@@ -82,6 +82,9 @@ func checkNodeStructure(n, g node, r *Report) {
 	case reflect.Struct:
 		for _, cn := range n.children {
 			if cg := g.Child(cn.name); cg.IsValid() {
+				if msg := cg.field.Tag.Get("deprecated"); msg != "" {
+					r.Warning(cn.line, fmt.Sprintf("deprecated key %q (%s)", cn.name, msg))
+				}
 				checkNodeStructure(cn, cg, r)
 			} else {
 				r.Warning(cn.line, fmt.Sprintf("unrecognized key %q", cn.name))

--- a/config/validate/rules_test.go
+++ b/config/validate/rules_test.go
@@ -119,6 +119,15 @@ func TestCheckStructure(t *testing.T) {
 			config: "coreos:\n  etcd:\n    discovery: good",
 		},
 
+		// Test for deprecated keys
+		{
+			config: "coreos:\n  etcd:\n    addr: hi",
+		},
+		{
+			config:  "coreos:\n  etcd:\n    proxy: hi",
+			entries: []Entry{{entryWarning, "deprecated key \"proxy\" (etcd2 options no longer work for etcd)", 3}},
+		},
+
 		// Test for error on list of nodes
 		{
 			config: "coreos:\n  units:\n    - hello\n    - goodbye",

--- a/initialize/config.go
+++ b/initialize/config.go
@@ -135,6 +135,7 @@ func Apply(cfg config.CloudConfig, ifaces []network.InterfaceGenerator, env *Env
 
 	for _, ccu := range []CloudConfigUnit{
 		system.Etcd{Etcd: cfg.CoreOS.Etcd},
+		system.Etcd2{Etcd2: cfg.CoreOS.Etcd2},
 		system.Fleet{Fleet: cfg.CoreOS.Fleet},
 		system.Locksmith{Locksmith: cfg.CoreOS.Locksmith},
 		system.Update{Update: cfg.CoreOS.Update, ReadConfig: system.DefaultReadConfig},

--- a/system/etcd2.go
+++ b/system/etcd2.go
@@ -1,0 +1,37 @@
+// Copyright 2015 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package system
+
+import (
+	"github.com/coreos/coreos-cloudinit/config"
+)
+
+// Etcd2 is a top-level structure which embeds its underlying configuration,
+// config.Etcd2, and provides the system-specific Unit().
+type Etcd2 struct {
+	config.Etcd2
+}
+
+// Units creates a Unit file drop-in for etcd, using any configured options.
+func (ee Etcd2) Units() []Unit {
+	return []Unit{{config.Unit{
+		Name:    "etcd2.service",
+		Runtime: true,
+		DropIns: []config.UnitDropIn{{
+			Name:    "20-cloudinit.conf",
+			Content: serviceContents(ee.Etcd2),
+		}},
+	}}}
+}


### PR DESCRIPTION
This fixes https://github.com/coreos/coreos-cloudinit/issues/329.
The list of deprecated options comes from https://github.com/coreos/coreos-cloudinit/pull/313.

Doing a little more testing...