### PR TITLE
units: run networkd after VM config

### DIFF
--- a/units/user-configdrive.service
+++ b/units/user-configdrive.service
@@ -4,6 +4,9 @@ Requires=coreos-setup-environment.service
 After=coreos-setup-environment.service system-config.target
 Before=user-config.target
 
+Requires=user-local-config-ready.target
+Before=user-local-config-ready.target
+
 # HACK: work around ordering between config drive and ec2 metadata It is
 # possible for OpenStack style systems to provide both the metadata service
 # and config drive, to prevent the two from stomping on eachother force

--- a/units/user-configvirtfs.service
+++ b/units/user-configvirtfs.service
@@ -4,6 +4,9 @@ Requires=coreos-setup-environment.service
 After=coreos-setup-environment.service
 Before=user-config.target
 
+Requires=user-local-config-ready.target
+Before=user-local-config-ready.target
+
 [Service]
 Type=oneshot
 RemainAfterExit=yes

--- a/units/user-local-config-ready.target
+++ b/units/user-local-config-ready.target
@@ -1,0 +1,5 @@
+[Unit]
+Description=Indicate that configs loaded from a local filesystem are ready
+
+# Start network after local configs created all-network related config files.
+Before=systemd-networkd.service


### PR DESCRIPTION
Fixes #343

Delay networkd start until config from /media/configvirtfs creates network-related files. This way under VM even on the first boot networkd uses correct network settings.