### PR TITLE
Bond options persisted to the generated netdev file.

### DIFF
--- a/network/interface.go
+++ b/network/interface.go
@@ -130,7 +130,17 @@ type bondInterface struct {
 }
 
 func (b *bondInterface) Netdev() string {
-	return fmt.Sprintf("[NetDev]\nKind=bond\nName=%s\n", b.name)
+	config := fmt.Sprintf("[NetDev]\nKind=bond\nName=%s\n", b.name)
+	if b.hwaddr != nil {
+		config += fmt.Sprintf("MACAddress=%s\n", b.hwaddr.String())
+	}
+
+	config += fmt.Sprintf("\n[Bond]\n")
+	for _, name := range sortedKeys(b.options) {
+		config += fmt.Sprintf("%s=%s\n", name, b.options[name])
+	}
+
+	return config
 }
 
 func (b *bondInterface) Type() string {

--- a/network/interface_test.go
+++ b/network/interface_test.go
@@ -52,7 +52,7 @@ func TestInterfaceGenerators(t *testing.T) {
 		},
 		{
 			name:    "testname",
-			netdev:  "[NetDev]\nKind=bond\nName=testname\n",
+			netdev:  "[NetDev]\nKind=bond\nName=testname\n\n[Bond]\n",
 			network: "[Match]\nName=testname\n\n[Network]\nBond=testbond1\nVLAN=testvlan1\nVLAN=testvlan2\nDHCP=true\n",
 			kind:    "bond",
 			iface: &bondInterface{logicalInterface: logicalInterface{


### PR DESCRIPTION
 Bond options aren't persisted to the files. This isn't a problem if you're relying on the network portions of coreos-cloudinit for every boot. Because the calls are made directly to configure the interface. 

However, the generated files didn't have the bond config in them. This meant that the .netdev file was largely incorrect.  This fixes that but might be better handled in a different options array.  

