### PR TITLE
Go ci versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,6 @@ matrix:
   include:
     - go: 1.4
       env: TOOLS_CMD=golang.org/x/tools/cmd
-    - go: 1.3
-      env: TOOLS_CMD=code.google.com/p/go.tools/cmd
-    - go: 1.2
-      env: TOOLS_CMD=code.google.com/p/go.tools/cmd
 
 install:
  - go get ${TOOLS_CMD}/cover


### PR DESCRIPTION
Removing 1.2 and 1.3 from TravisCI testing. 