### PR TITLE
Add PublicIP option on flannel

### DIFF
--- a/Documentation/cloud-config.md
+++ b/Documentation/cloud-config.md
@@ -169,6 +169,7 @@ List of flannel configuration parameters:
 - **ip_masq**: Install IP masquerade rules for traffic outside of flannel subnet
 - **subnet_file**: Path to flannel subnet file to write out
 - **interface**: Interface (name or IP) that should be used for inter-host communication
+- **public_ip**: IP accessible by other nodes for inter-host communication
 
 [flannel-readme]: https://github.com/coreos/flannel/blob/master/README.md
 

--- a/config/flannel.go
+++ b/config/flannel.go
@@ -23,4 +23,5 @@ type Flannel struct {
 	IPMasq        string `yaml:"ip_masq"        env:"FLANNELD_IP_MASQ"`
 	SubnetFile    string `yaml:"subnet_file"    env:"FLANNELD_SUBNET_FILE"`
 	Iface         string `yaml:"interface"      env:"FLANNELD_IFACE"`
+	PublicIP      string `yaml:"public_ip"      env:"FLANNELD_PUBLIC_IP"`
 }


### PR DESCRIPTION
Related with coreos/flannel#259

This will allow users to use flannel under a **NAT** environment easily, by just setting `public_ip: $public_ipv4` on their `cloud-config`.

Example:
```
#cloud-config

coreos:
    flannel:
        public-ip: $public_ipv4
```