### PR TITLE
units: add path condition !/etc/.disable-cloudinit on all units

### DIFF
--- a/units/media-configdrive.mount
+++ b/units/media-configdrive.mount
@@ -7,6 +7,9 @@ ConditionVirtualization=|vm
 ConditionKernelCommandLine=|coreos.configdrive=1
 ConditionKernelCommandLine=!coreos.configdrive=0
 
+# Inhibit all cloudinit-related activities if ignition disabled us.
+ConditionPathExists=!/etc/.disable-cloudinit
+
 [Mount]
 What=LABEL=config-2
 Where=/media/configdrive

--- a/units/media-configvirtfs.mount
+++ b/units/media-configvirtfs.mount
@@ -7,6 +7,9 @@ ConditionVirtualization=|vm
 ConditionKernelCommandLine=|coreos.configdrive=1
 ConditionKernelCommandLine=!coreos.configdrive=0
 
+# Inhibit all cloudinit-related activities if ignition disabled us.
+ConditionPathExists=!/etc/.disable-cloudinit
+
 # Support old style setup for now
 Wants=addon-run@media-configvirtfs.service addon-config@media-configvirtfs.service
 Before=addon-run@media-configvirtfs.service addon-config@media-configvirtfs.service

--- a/units/system-cloudinit@.service
+++ b/units/system-cloudinit@.service
@@ -5,6 +5,9 @@ After=dbus.service
 Before=system-config.target
 ConditionFileNotEmpty=%f
 
+# Inhibit all cloudinit-related activities if ignition disabled us.
+ConditionPathExists=!/etc/.disable-cloudinit
+
 [Service]
 Type=oneshot
 RemainAfterExit=yes

--- a/units/system-config.target
+++ b/units/system-config.target
@@ -1,6 +1,9 @@
 [Unit]
 Description=Load system-provided cloud configs
 
+# Inhibit all cloudinit-related activities if ignition disabled us.
+ConditionPathExists=!/etc/.disable-cloudinit
+
 # Generate /etc/environment
 Requires=coreos-setup-environment.service
 After=coreos-setup-environment.service

--- a/units/user-cloudinit-proc-cmdline.service
+++ b/units/user-cloudinit-proc-cmdline.service
@@ -5,6 +5,9 @@ After=coreos-setup-environment.service
 Before=user-config.target
 ConditionKernelCommandLine=cloud-config-url
 
+# Inhibit all cloudinit-related activities if ignition disabled us.
+ConditionPathExists=!/etc/.disable-cloudinit
+
 [Service]
 Type=oneshot
 RemainAfterExit=yes

--- a/units/user-cloudinit@.path
+++ b/units/user-cloudinit@.path
@@ -1,5 +1,8 @@
 [Unit]
 Description=Watch for a cloud-config at %f
 
+# Inhibit all cloudinit-related activities if ignition disabled us.
+ConditionPathExists=!/etc/.disable-cloudinit
+
 [Path]
 PathExists=%f

--- a/units/user-cloudinit@.service
+++ b/units/user-cloudinit@.service
@@ -5,6 +5,9 @@ After=coreos-setup-environment.service
 Before=user-config.target
 ConditionFileNotEmpty=%f
 
+# Inhibit all cloudinit-related activities if ignition disabled us.
+ConditionPathExists=!/etc/.disable-cloudinit
+
 [Service]
 Type=oneshot
 RemainAfterExit=yes

--- a/units/user-config.target
+++ b/units/user-config.target
@@ -3,6 +3,9 @@ Description=Load user-provided cloud configs
 Requires=system-config.target
 After=system-config.target
 
+# Inhibit all cloudinit-related activities if ignition disabled us.
+ConditionPathExists=!/etc/.disable-cloudinit
+
 # Watch for configs at a couple common paths
 Requires=user-configdrive.path
 After=user-configdrive.path

--- a/units/user-configdrive.path
+++ b/units/user-configdrive.path
@@ -1,6 +1,9 @@
 [Unit]
 Description=Watch for a cloud-config at /media/configdrive
 
+# Inhibit all cloudinit-related activities if ignition disabled us.
+ConditionPathExists=!/etc/.disable-cloudinit
+
 # Note: This unit is essentially just here as a fall-back mechanism to
 # trigger cloudinit if it isn't triggered explicitly by other means
 # such as by a Wants= in the mount unit. This ensures we handle the

--- a/units/user-configdrive.service
+++ b/units/user-configdrive.service
@@ -4,6 +4,9 @@ Requires=coreos-setup-environment.service
 After=coreos-setup-environment.service system-config.target
 Before=user-config.target
 
+# Inhibit all cloudinit-related activities if ignition disabled us.
+ConditionPathExists=!/etc/.disable-cloudinit
+
 # HACK: work around ordering between config drive and ec2 metadata It is
 # possible for OpenStack style systems to provide both the metadata service
 # and config drive, to prevent the two from stomping on eachother force

--- a/units/user-configvirtfs.service
+++ b/units/user-configvirtfs.service
@@ -4,6 +4,9 @@ Requires=coreos-setup-environment.service
 After=coreos-setup-environment.service
 Before=user-config.target
 
+# Inhibit all cloudinit-related activities if ignition disabled us.
+ConditionPathExists=!/etc/.disable-cloudinit
+
 [Service]
 Type=oneshot
 RemainAfterExit=yes


### PR DESCRIPTION
When ignition runs, it will touch /etc/.disable-cloudinit, since we want
them to be mutually exclusive.