### PR TITLE
metadata: Support gzip cloud-config from metadata

### DIFF
--- a/datasource/metadata/metadata.go
+++ b/datasource/metadata/metadata.go
@@ -17,6 +17,7 @@ package metadata
 import (
 	"strings"
 
+	"github.com/coreos/coreos-cloudinit/config"
 	"github.com/coreos/coreos-cloudinit/pkg"
 )
 
@@ -49,7 +50,13 @@ func (ms MetadataService) ConfigRoot() string {
 }
 
 func (ms MetadataService) FetchUserdata() ([]byte, error) {
-	return ms.FetchData(ms.UserdataUrl())
+	if data, err := ms.FetchData(ms.UserdataUrl()); err != nil {
+		return data, err
+	} else if t_data, t_err := config.DecodeGzipContent(string(data[:])); t_err != nil {
+		return data, err
+	} else {
+		return t_data, t_err
+	}
 }
 
 func (ms MetadataService) FetchData(url string) ([]byte, error) {

--- a/datasource/metadata/metadata_test.go
+++ b/datasource/metadata/metadata_test.go
@@ -63,6 +63,10 @@ func TestIsAvailable(t *testing.T) {
 }
 
 func TestFetchUserdata(t *testing.T) {
+	gzip_payload := fmt.Sprint("\x1f\x8b\x08\x00\xbd\x5d\xce\x55\x00\x03\x53\x4e",
+		"\xce\xc9\x2f\x4d\xd1\x4d\xce\xcf\x4b\xcb\x4c\x07",
+		"\x00\x1b\x7a\x99\x01\x0d\x00\x00\x00")
+
 	for _, tt := range []struct {
 		root         string
 		userdataPath string
@@ -78,6 +82,14 @@ func TestFetchUserdata(t *testing.T) {
 				"/2009-04-04/user-data": "hello",
 			},
 			userdata: []byte("hello"),
+		},
+		{
+			root:         "/",
+			userdataPath: "2009-04-04/user-data",
+			resources: map[string]string{
+				"/2009-04-04/user-data": gzip_payload,
+			},
+			userdata: []byte("#cloud-config"),
 		},
 		{
 			root:      "/",


### PR DESCRIPTION
Implements https://cloudinit.readthedocs.org/en/latest/topics/format.html#gzip-compressed-content for metadata services.