### PR TITLE
Trim trailing whitespaces in #cloud-config header

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -19,6 +19,7 @@ import (
 	"reflect"
 	"regexp"
 	"strings"
+	"unicode"
 
 	"github.com/coreos/coreos-cloudinit/Godeps/_workspace/src/github.com/coreos/yaml"
 )
@@ -49,10 +50,8 @@ type CoreOS struct {
 func IsCloudConfig(userdata string) bool {
 	header := strings.SplitN(userdata, "\n", 2)[0]
 
-	// Explicitly trim the header so we can handle user-data from
-	// non-unix operating systems. The rest of the file is parsed
-	// by yaml, which correctly handles CRLF.
-	header = strings.TrimSuffix(header, "\r")
+	// Trim trailing whitespaces
+	header = strings.TrimRightFunc(header, unicode.IsSpace)
 
 	return (header == "#cloud-config")
 }

--- a/initialize/user_data_test.go
+++ b/initialize/user_data_test.go
@@ -47,7 +47,7 @@ func TestParseHeaderCRLF(t *testing.T) {
 }
 
 func TestParseConfigCRLF(t *testing.T) {
-	contents := "#cloud-config\r\nhostname: foo\r\nssh_authorized_keys:\r\n  - foobar\r\n"
+	contents := "#cloud-config \r\nhostname: foo\r\nssh_authorized_keys:\r\n  - foobar\r\n"
 	ud, err := ParseUserData(contents)
 	if err != nil {
 		t.Fatalf("Failed parsing config: %v", err)


### PR DESCRIPTION
If cloud-config contains trailing whitespaces in the header - coreos-cloudinit will fail that config. Example has trailing whitespace and you can not see it:

```
#cloud-config 
```

/cc @robszumski 
/cc @crawford 