### PR TITLE
datasource/vmware: introduce guestinfo.coreos.config.url

### DIFF
--- a/Documentation/vmware-backdoor.md
+++ b/Documentation/vmware-backdoor.md
@@ -19,6 +19,7 @@ are supported by coreos-cloudinit:
 | `dns.server.<x>`                      | `IP address`                    |
 | `coreos.config.data`                  | `string`                        |
 | `coreos.config.data.encoding`         | `{"", "base64", "gzip+base64"}` |
+| `coreos.config.url`                   | `URL`                           |
 
 Note: "n", "m", "l", and "x" are 0-indexed, incrementing integers. The
 identifier for the interfaces does not correspond to anything outside of this


### PR DESCRIPTION
allow use of a URL instead of an inline document.
Inline document takes precedence.