### PR TITLE
datasource/vmware: add support for reading from OVF environment

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -32,7 +32,11 @@
 		},
 		{
 			"ImportPath": "github.com/sigma/vmw-guestinfo",
-			"Rev": "de573afc542e0268fe8478d46e237fad9d6f7aec"
+			"Rev": "c036b3e8a5c2736a7b1ab6eb8a52d18a87779820"
+		},
+		{
+			"ImportPath": "github.com/sigma/vmw-ovflib",
+			"Rev": "56b4f44581cac03d17d8270158bdfd0942ffe790"
 		}
 	]
 }

--- a/Godeps/_workspace/src/github.com/sigma/vmw-ovflib/README
+++ b/Godeps/_workspace/src/github.com/sigma/vmw-ovflib/README
@@ -1,0 +1,1 @@
+minimal support for parsing OVF environment

--- a/Godeps/_workspace/src/github.com/sigma/vmw-ovflib/ovf.go
+++ b/Godeps/_workspace/src/github.com/sigma/vmw-ovflib/ovf.go
@@ -1,0 +1,42 @@
+package ovf
+
+import (
+	"encoding/xml"
+	"log"
+)
+
+type environment struct {
+	Platform   platform   `xml:"PlatformSection"`
+	Properties []property `xml:"PropertySection>Property"`
+}
+
+type platform struct {
+	Kind    string `xml:"Kind"`
+	Version string `xml:"Version"`
+	Vendor  string `xml:"Vendor"`
+	Locale  string `xml:"Locale"`
+}
+
+type property struct {
+	Key   string `xml:"key,attr"`
+	Value string `xml:"value,attr"`
+}
+
+type OvfEnvironment struct {
+	Platform   platform
+	Properties map[string]string
+}
+
+func ReadEnvironment(doc []byte) *OvfEnvironment {
+	var env environment
+	if err := xml.Unmarshal(doc, &env); err != nil {
+		log.Fatalln(err)
+	}
+
+	dict := make(map[string]string)
+	for _, p := range env.Properties {
+		dict[p.Key] = p.Value
+	}
+	return &OvfEnvironment{Properties: dict,
+		Platform: env.Platform}
+}

--- a/Godeps/_workspace/src/github.com/sigma/vmw-ovflib/ovf_test.go
+++ b/Godeps/_workspace/src/github.com/sigma/vmw-ovflib/ovf_test.go
@@ -1,0 +1,110 @@
+package ovf
+
+import (
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+var data_vsphere = []byte(`<?xml version="1.0" encoding="UTF-8"?>
+<Environment
+     xmlns="http://schemas.dmtf.org/ovf/environment/1"
+     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+     xmlns:oe="http://schemas.dmtf.org/ovf/environment/1"
+     xmlns:ve="http://www.vmware.com/schema/ovfenv"
+     oe:id=""
+     ve:vCenterId="vm-12345">
+   <PlatformSection>
+      <Kind>VMware ESXi</Kind>
+      <Version>5.5.0</Version>
+      <Vendor>VMware, Inc.</Vendor>
+      <Locale>en</Locale>
+   </PlatformSection>
+   <PropertySection>
+         <Property oe:key="foo" oe:value="42"/>
+         <Property oe:key="bar" oe:value="0"/>
+   </PropertySection>
+   <ve:EthernetAdapterSection>
+      <ve:Adapter ve:mac="00:00:00:00:00:00" ve:network="foo" ve:unitNumber="7"/>
+   </ve:EthernetAdapterSection>
+</Environment>`)
+
+var data_vapprun = []byte(`<?xml version="1.0" encoding="UTF-8"?>
+<Environment xmlns="http://schemas.dmtf.org/ovf/environment/1"
+     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+     xmlns:oe="http://schemas.dmtf.org/ovf/environment/1"
+     oe:id="CoreOS-vmw">
+   <PlatformSection>
+      <Kind>vapprun</Kind>
+      <Version>1.0</Version>
+      <Vendor>VMware, Inc.</Vendor>
+      <Locale>en_US</Locale>
+   </PlatformSection>
+   <PropertySection>
+      <Property oe:key="foo" oe:value="42"/>
+      <Property oe:key="bar" oe:value="0"/>
+      <Property oe:key="guestinfo.user_data.url" oe:value="https://gist.githubusercontent.com/sigma/5a64aac1693da9ca70d2/raw/plop.yaml"/>
+      <Property oe:key="guestinfo.user_data.doc" oe:value=""/>
+      <Property oe:key="guestinfo.meta_data.url" oe:value=""/>
+      <Property oe:key="guestinfo.meta_data.doc" oe:value=""/>
+   </PropertySection>
+</Environment>`)
+
+func TestOvfEnvProperties(t *testing.T) {
+
+	var testerFunc = func(env_str []byte) func() {
+		return func() {
+			env := ReadEnvironment(env_str)
+			props := env.Properties
+
+			var val string
+			var ok bool
+			Convey(`Property "foo"`, func() {
+				val, ok = props["foo"]
+				So(ok, ShouldBeTrue)
+				So(val, ShouldEqual, "42")
+			})
+
+			Convey(`Property "bar"`, func() {
+				val, ok = props["bar"]
+				So(ok, ShouldBeTrue)
+				So(val, ShouldEqual, "0")
+			})
+		}
+	}
+
+	Convey("With vAppRun environment", t, testerFunc(data_vapprun))
+	Convey("With vSphere environment", t, testerFunc(data_vsphere))
+}
+
+func TestOvfEnvPlatform(t *testing.T) {
+	Convey("With vSphere environment", t, func() {
+		env := ReadEnvironment(data_vsphere)
+		platform := env.Platform
+
+		So(platform.Kind, ShouldEqual, "VMware ESXi")
+		So(platform.Version, ShouldEqual, "5.5.0")
+		So(platform.Vendor, ShouldEqual, "VMware, Inc.")
+		So(platform.Locale, ShouldEqual, "en")
+	})
+}
+
+func TestVappRunUserDataUrl(t *testing.T) {
+	Convey("With vAppRun environment", t, func() {
+		env := ReadEnvironment(data_vapprun)
+		props := env.Properties
+
+		var val string
+		var ok bool
+
+		val, ok = props["guestinfo.user_data.url"]
+		So(ok, ShouldBeTrue)
+		So(val, ShouldEqual, "https://gist.githubusercontent.com/sigma/5a64aac1693da9ca70d2/raw/plop.yaml")
+	})
+}
+
+func TestInvalidData(t *testing.T) {
+	Convey("With invalid data", t, func() {
+		ReadEnvironment(append(data_vsphere, []byte("garbage")...))
+	})
+}

--- a/coreos-cloudinit.go
+++ b/coreos-cloudinit.go
@@ -67,6 +67,7 @@ var (
 			url                         string
 			procCmdLine                 bool
 			vmware                      bool
+			ovfEnv                      string
 		}
 		convertNetconf string
 		workspace      string
@@ -91,6 +92,7 @@ func init() {
 	flag.StringVar(&flags.sources.url, "from-url", "", "Download user-data from provided url")
 	flag.BoolVar(&flags.sources.procCmdLine, "from-proc-cmdline", false, fmt.Sprintf("Parse %s for '%s=<url>', using the cloud-config served by an HTTP GET to <url>", proc_cmdline.ProcCmdlineLocation, proc_cmdline.ProcCmdlineCloudConfigFlag))
 	flag.BoolVar(&flags.sources.vmware, "from-vmware-guestinfo", false, "Read data from VMware guestinfo")
+	flag.StringVar(&flags.sources.ovfEnv, "from-vmware-ovf-env", "", "Read data from OVF Environment")
 	flag.StringVar(&flags.oem, "oem", "", "Use the settings specific to the provided OEM")
 	flag.StringVar(&flags.convertNetconf, "convert-netconf", "", "Read the network config provided in cloud-drive and translate it from the specified format into networkd unit files")
 	flag.StringVar(&flags.workspace, "workspace", "/var/lib/coreos-cloudinit", "Base directory coreos-cloudinit should use to store data")
@@ -125,7 +127,7 @@ var (
 		},
 		"vmware": oemConfig{
 			"from-vmware-guestinfo": "true",
-			"convert-netconf":      "vmware",
+			"convert-netconf":       "vmware",
 		},
 	}
 )
@@ -336,7 +338,10 @@ func getDatasources() []datasource.Datasource {
 		dss = append(dss, proc_cmdline.NewDatasource())
 	}
 	if flags.sources.vmware {
-		dss = append(dss, vmware.NewDatasource())
+		dss = append(dss, vmware.NewDatasource(""))
+	}
+	if flags.sources.ovfEnv != "" {
+		dss = append(dss, vmware.NewDatasource(flags.sources.ovfEnv))
 	}
 	return dss
 }

--- a/units/90-ovfenv.rules
+++ b/units/90-ovfenv.rules
@@ -1,0 +1,8 @@
+# Automatically trigger ovfenv mounting.
+
+ACTION!="add|change", GOTO="coreos_ovfenv_end"
+
+# A normal config drive. Block device formatted with iso9660 or fat
+SUBSYSTEM=="block", ENV{ID_FS_TYPE}=="iso9660|vfat", ENV{ID_FS_LABEL}=="OVF_ENV", TAG+="systemd", ENV{SYSTEMD_WANTS}+="media-ovfenv.mount"
+
+LABEL="coreos_ovfenv_end"

--- a/units/media-ovfenv.mount
+++ b/units/media-ovfenv.mount
@@ -1,0 +1,10 @@
+[Unit]
+Wants=user-config-ovfenv.service
+Before=user-config-ovfenv.service
+# Only mount ovfenv drive block devices automatically in virtual machines
+ConditionVirtualization=vmware
+
+[Mount]
+What=LABEL="OVF ENV"
+Where=/media/ovfenv
+Options=ro

--- a/units/user-config-ovfenv.service
+++ b/units/user-config-ovfenv.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Load cloud-config from /media/ovfenv
+Requires=coreos-setup-environment.service
+After=coreos-setup-environment.service system-config.target
+Before=user-config.target
+After=user-config-vmw-tools.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+EnvironmentFile=-/etc/environment
+ExecStart=/usr/bin/coreos-cloudinit --from-vmware-ovf-env=/media/ovfenv/ovf-env.xml

--- a/units/user-config.target
+++ b/units/user-config.target
@@ -11,3 +11,6 @@ After=user-cloudinit@var-lib-coreos\x2dinstall-user_data.path
 
 Requires=user-cloudinit-proc-cmdline.service
 After=user-cloudinit-proc-cmdline.service
+
+Requires=user-config-ovfenv.path
+After=user-config-ovfenv.path


### PR DESCRIPTION
If an OVF environment is present (either through VMware backdoor, or as a
mounted cdrom), use it to extract user/meta data.