### PR TITLE
units: added network-online.target dependency for user-cloudinit-proc…

### DIFF
--- a/units/user-cloudinit-proc-cmdline.service
+++ b/units/user-cloudinit-proc-cmdline.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Load cloud-config from url defined in /proc/cmdline
-Requires=coreos-setup-environment.service
-After=coreos-setup-environment.service
+Requires=coreos-setup-environment.service network-online.target
+After=coreos-setup-environment.service network-online.target
 Before=user-config.target
 ConditionKernelCommandLine=cloud-config-url
 


### PR DESCRIPTION
…-cmdline.service

/cc @robszumski @marineam @crawford 

When dhcp server works slowly, coreos-cloudinit just fails because network is not yet ready. This commit should solve the issue.