### PR TITLE
cloudinit: Removing convert-netconf from Packet OEM

### DIFF
--- a/coreos-cloudinit.go
+++ b/coreos-cloudinit.go
@@ -118,7 +118,6 @@ var (
 		},
 		"packet": oemConfig{
 			"from-packet-metadata": "https://metadata.packet.net/",
-			"convert-netconf":      "packet",
 		},
 		"vmware": oemConfig{
 			"from-vmware-backdoor": "true",


### PR DESCRIPTION
We still utilize the network code on first boot, so it should remain until we implement ignition, but we don't want it on subsequent boots, which is what this line would do.