### PR TITLE
datasource, network: add support for DigitalOcean floating IPs

### DIFF
--- a/datasource/metadata/digitalocean/metadata.go
+++ b/datasource/metadata/digitalocean/metadata.go
@@ -38,10 +38,11 @@ type Address struct {
 }
 
 type Interface struct {
-	IPv4 *Address `json:"ipv4"`
-	IPv6 *Address `json:"ipv6"`
-	MAC  string   `json:"mac"`
-	Type string   `json:"type"`
+	IPv4       *Address `json:"ipv4"`
+	IPv6       *Address `json:"ipv6"`
+	AnchorIPv4 *Address `json:"anchor_ipv4"`
+	MAC        string   `json:"mac"`
+	Type       string   `json:"type"`
 }
 
 type Interfaces struct {

--- a/network/digitalocean.go
+++ b/network/digitalocean.go
@@ -126,6 +126,32 @@ func parseInterface(iface digitalocean.Interface, nameservers []net.IP, useRoute
 			})
 		}
 	}
+	if iface.AnchorIPv4 != nil {
+		var ip, mask, gateway net.IP
+		if ip = net.ParseIP(iface.AnchorIPv4.IPAddress); ip == nil {
+			return nil, fmt.Errorf("could not parse %q as anchor IPv4 address", iface.AnchorIPv4.IPAddress)
+		}
+		if mask = net.ParseIP(iface.AnchorIPv4.Netmask); mask == nil {
+			return nil, fmt.Errorf("could not parse %q as anchor IPv4 mask", iface.AnchorIPv4.Netmask)
+		}
+		addresses = append(addresses, net.IPNet{
+			IP:   ip,
+			Mask: net.IPMask(mask),
+		})
+
+		if useRoute {
+			if gateway = net.ParseIP(iface.AnchorIPv4.Gateway); gateway == nil {
+				return nil, fmt.Errorf("could not parse %q as anchor IPv4 gateway", iface.AnchorIPv4.Gateway)
+			}
+			routes = append(routes, route{
+				destination: net.IPNet{
+					IP:   net.IPv4zero,
+					Mask: net.IPMask(net.IPv4zero),
+				},
+				gateway: gateway,
+			})
+		}
+	}
 
 	hwaddr, err := net.ParseMAC(iface.MAC)
 	if err != nil {


### PR DESCRIPTION
First pass at allowing CoreOS droplets on DigitalOcean to parse their "anchor IP" which is used to rewrite traffic from a floating IP into the droplet.

The intent here is to add a second IPv4 address to the primary network interface.  I've updated the tests to reflect this as well.  Please let me know if I'm doing anything incorrectly, and thanks for your time.

/cc @crawford 