### PR TITLE
gzip autodetection

### DIFF
--- a/coreos-cloudinit.go
+++ b/coreos-cloudinit.go
@@ -15,8 +15,11 @@
 package main
 
 import (
+	"bytes"
+	"compress/gzip"
 	"flag"
 	"fmt"
+	"io/ioutil"
 	"log"
 	"os"
 	"sync"
@@ -176,6 +179,11 @@ func main() {
 	userdataBytes, err := ds.FetchUserdata()
 	if err != nil {
 		log.Printf("Failed fetching user-data from datasource: %v. Continuing...\n", err)
+		failure = true
+	}
+	userdataBytes, err = decompressIfGzip(userdataBytes)
+	if err != nil {
+		log.Printf("Failed decompressing user-data from datasource: %v. Continuing...\n", err)
 		failure = true
 	}
 
@@ -391,4 +399,18 @@ func runScript(script config.Script, env *initialize.Environment) error {
 		initialize.PersistUnitNameInWorkspace(name, env.Workspace())
 	}
 	return err
+}
+
+const gzipMagicBytes = "\x1f\x8b"
+
+func decompressIfGzip(userdataBytes []byte) ([]byte, error) {
+	if !bytes.HasPrefix(userdataBytes, []byte(gzipMagicBytes)) {
+		return userdataBytes, nil
+	}
+	gzr, err := gzip.NewReader(bytes.NewReader(userdataBytes))
+	if err != nil {
+		return nil, err
+	}
+	defer gzr.Close()
+	return ioutil.ReadAll(gzr)
 }

--- a/test
+++ b/test
@@ -21,6 +21,7 @@ SRC="
 	network
 	pkg
 	system
+	.
 "
 
 echo "Checking gofix..."


### PR DESCRIPTION
The cloud-init project uses a similar technique to natively support gzipped user-data. The alternative path would be to use a script that decompresses the user data and then calls into cloudinit, but this seemed simple enough to bring into cloudinit itself.

And, unrelated, but in the same commit – without the change to `test`, I found that the top-level tests in coreos-cloudinit_test.go were not running.