### PR TITLE
config: add wal_dir into etcd2.go

### DIFF
--- a/config/etcd2.go
+++ b/config/etcd2.go
@@ -53,4 +53,5 @@ type Etcd2 struct {
 	ProxyWriteTimeout        int    `yaml:"proxy_write_timeout"           env:"ETCD_PROXY_WRITE_TIMEOUT"`
 	SnapshotCount            int    `yaml:"snapshot_count"                env:"ETCD_SNAPSHOT_COUNT"`
 	TrustedCAFile            string `yaml:"trusted_ca_file"               env:"ETCD_TRUSTED_CA_FILE"`
+	WalDir                   string `yaml:"wal_dir"                       env:"ETCD_WAL_DIR"`
 }


### PR DESCRIPTION
In etcd 2.2 release, we introduced a new flag called `walDir`.

See https://github.com/coreos/etcd/blob/release-2.2/Documentation/configuration.md#-wal-dir for more details.