### PR TITLE
network: do not assign gateway for DigitalOcean anchor IP address

### DIFF
--- a/network/digitalocean.go
+++ b/network/digitalocean.go
@@ -127,7 +127,7 @@ func parseInterface(iface digitalocean.Interface, nameservers []net.IP, useRoute
 		}
 	}
 	if iface.AnchorIPv4 != nil {
-		var ip, mask, gateway net.IP
+		var ip, mask net.IP
 		if ip = net.ParseIP(iface.AnchorIPv4.IPAddress); ip == nil {
 			return nil, fmt.Errorf("could not parse %q as anchor IPv4 address", iface.AnchorIPv4.IPAddress)
 		}
@@ -140,15 +140,11 @@ func parseInterface(iface digitalocean.Interface, nameservers []net.IP, useRoute
 		})
 
 		if useRoute {
-			if gateway = net.ParseIP(iface.AnchorIPv4.Gateway); gateway == nil {
-				return nil, fmt.Errorf("could not parse %q as anchor IPv4 gateway", iface.AnchorIPv4.Gateway)
-			}
 			routes = append(routes, route{
 				destination: net.IPNet{
 					IP:   net.IPv4zero,
 					Mask: net.IPMask(net.IPv4zero),
 				},
-				gateway: gateway,
 			})
 		}
 	}

--- a/network/digitalocean_test.go
+++ b/network/digitalocean_test.go
@@ -284,19 +284,6 @@ func TestParseInterface(t *testing.T) {
 		{
 			cfg: digitalocean.Interface{
 				MAC: "01:23:45:67:89:AB",
-				AnchorIPv4: &digitalocean.Address{
-					IPAddress: "1.2.3.4",
-					Netmask:   "255.255.0.0",
-					Gateway:   "bad",
-				},
-			},
-			useRoute: true,
-			nss:      []net.IP{},
-			err:      errors.New("could not parse \"bad\" as anchor IPv4 gateway"),
-		},
-		{
-			cfg: digitalocean.Interface{
-				MAC: "01:23:45:67:89:AB",
 				IPv4: &digitalocean.Address{
 					IPAddress: "1.2.3.4",
 					Netmask:   "255.255.0.0",
@@ -305,7 +292,6 @@ func TestParseInterface(t *testing.T) {
 				AnchorIPv4: &digitalocean.Address{
 					IPAddress: "7.8.9.10",
 					Netmask:   "255.255.0.0",
-					Gateway:   "11.12.13.14",
 				},
 			},
 			useRoute: true,
@@ -326,12 +312,11 @@ func TestParseInterface(t *testing.T) {
 					nameservers: []net.IP{},
 					routes: []route{
 						{
-							net.IPNet{IP: net.IPv4zero, Mask: net.IPMask(net.IPv4zero)},
-							net.ParseIP("5.6.7.8"),
+							destination: net.IPNet{IP: net.IPv4zero, Mask: net.IPMask(net.IPv4zero)},
+							gateway:     net.ParseIP("5.6.7.8"),
 						},
 						{
-							net.IPNet{IP: net.IPv4zero, Mask: net.IPMask(net.IPv4zero)},
-							net.ParseIP("11.12.13.14"),
+							destination: net.IPNet{IP: net.IPv4zero, Mask: net.IPMask(net.IPv4zero)},
 						},
 					},
 				},


### PR DESCRIPTION
Fixes issue where containers are unable to reach the network due to multiple gateways.  Tested and confirmed working on our platform.

```
core@core ~ $ ip addr show dev eth0
2: eth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc fq_codel state UP group default qlen 1000
    link/ether 04:01:80:ba:e5:01 brd ff:ff:ff:ff:ff:ff
    inet 169.254.57.197/16 brd 169.254.255.255 scope link eth0
       valid_lft forever preferred_lft forever
    inet 159.203.20.240/20 brd 159.203.31.255 scope global eth0
       valid_lft forever preferred_lft forever
    inet 10.20.0.5/16 brd 10.20.255.255 scope global eth0
       valid_lft forever preferred_lft forever
    inet6 fe80::601:80ff:feba:e501/64 scope link 
       valid_lft forever preferred_lft forever
core@core ~ $ ip route
default via 159.203.16.1 dev eth0  proto static 
default dev eth0  proto static  scope link  metric 2048 
10.20.0.0/16 dev eth0  proto kernel  scope link  src 10.20.0.5 
159.203.16.0/20 dev eth0  proto kernel  scope link  src 159.203.20.240 
169.254.0.0/16 dev eth0  proto kernel  scope link  src 169.254.57.197 
172.17.0.0/16 dev docker0  proto kernel  scope link  src 172.17.42.1
```

```
core@core ~ $ docker run -p 80:80 -t -i ubuntu /bin/bash                                                                                            
root@0a00780e0813:/# nc -l 80
a # public IP address
a
a
a
a
root@0a00780e0813:/# nc -l 80
b # floating IP address
b
b
b
b
b
```

/cc @crawford 