### PR TITLE
Docs/vmware-backdoor: Rename backdoor to guestinfo

### DIFF
--- a/Documentation/cloud-config-locations.md
+++ b/Documentation/cloud-config-locations.md
@@ -12,15 +12,15 @@ Location | Description
 |`/var/lib/coreos-vagrant/vagrantfile-user-data`| Vagrant OEM scripts automatically store Cloud-Config into this path. |
 |`/var/lib/waagent/CustomData`| Azure platform uses OEM path for first Cloud-Config initialization and then `/var/lib/waagent/CustomData` to apply your settings.|
 |`http://169.254.169.254/metadata/v1/user-data` `http://169.254.169.254/2009-04-04/user-data` `https://metadata.packet.net/userdata`|DigitalOcean, EC2 and Packet cloud providers correspondingly use these URLs to download Cloud-Config.|
-|`/usr/share/oem/bin/vmtoolsd --cmd "info-get guestinfo.coreos.config.data"`|Cloud-Config provided by [VMware Backdoor][VMware Backdoor]|
-|`/usr/share/oem/bin/vmtoolsd --cmd "info-get guestinfo.coreos.config.url"`|Cloud-Config URL provided by [VMware Backdoor][VMware Backdoor]|
+|`/usr/share/oem/bin/vmtoolsd --cmd "info-get guestinfo.coreos.config.data"`|Cloud-Config provided by [VMware Guestinfo][VMware Guestinfo]|
+|`/usr/share/oem/bin/vmtoolsd --cmd "info-get guestinfo.coreos.config.url"`|Cloud-Config URL provided by [VMware Guestinfo][VMware Guestinfo]|
 
-[VMware Backdoor]: vmware-backdoor.md
+[VMware Guestinfo]: vmware-guestinfo.md
 
 You can also run the `coreos-cloudinit` tool manually and provide a path to your custom Cloud-Config file:
 
 ```sh
 sudo coreos-cloudinit --from-file=/home/core/cloud-config.yaml
-``` 
+```
 
 This command will apply your custom cloud-config.

--- a/Documentation/vmware-guestinfo.md
+++ b/Documentation/vmware-guestinfo.md
@@ -1,14 +1,16 @@
-# VMware Backdoor
+# VMWare Guestinfo Interface
 
-## Cloud-Config Options List
+## Cloud-Config VMWare Guestinfo Variables
 
-coreos-cloudinit is capable of reading userdata and metadata from the VMware
-backdoor. This datasource can be enabled with the `--from-vmware-backdoor` flag.
-Userdata and metadata are passed from the hypervisor to the virtual machine
-through guest variables. The following guest variables and their expected types
-are supported by coreos-cloudinit:
+coreos-cloudinit accepts configuration from the VMware RPC API's *guestinfo*
+facility. This datasource can be enabled with the `-from-vmware-guestinfo`
+flag to coreos-cloudinit.
 
-|            guest variable             |              type               |
+The following guestinfo variables are recognized and processed by cloudinit
+when passed from the hypervisor to the virtual machine at boot time. Note that
+property names are prefixed with `guestinfo.` in the VMX, e.g., `guestinfo.hostname`.
+
+|            guestinfo variable             |              type               |
 |:--------------------------------------|:--------------------------------|
 | `hostname`                            | `hostname`                      |
 | `interface.<n>.name`                  | `string`                        |
@@ -24,9 +26,10 @@ are supported by coreos-cloudinit:
 | `coreos.config.url`                   | `URL`                           |
 
 Note: "n", "m", "l", and "x" are 0-indexed, incrementing integers. The
-identifier for the interfaces does not correspond to anything outside of this
-configuration; it is merely for mapping configuration values to each interface.
+identifier for an `interface` does not correspond to anything outside of this
+configuration; it serves only to distinguish between multiple `interface`s.
 
-Please refer to [link][vmware] to know more how to run CoreOS on VMware.
+The guide to [booting on VMWare][bootvmware] is the starting point for more
+information about configuring and running CoreOS on VMWare.
 
-[vmware]: https://github.com/coreos/docs/blob/master/os/booting-on-vmware.md
+[bootvmware]: https://github.com/coreos/docs/blob/master/os/booting-on-vmware.md

--- a/coreos-cloudinit.go
+++ b/coreos-cloudinit.go
@@ -87,7 +87,7 @@ func init() {
 	flag.StringVar(&flags.sources.packetMetadataService, "from-packet-metadata", "", "Download Packet data from metadata service")
 	flag.StringVar(&flags.sources.url, "from-url", "", "Download user-data from provided url")
 	flag.BoolVar(&flags.sources.procCmdLine, "from-proc-cmdline", false, fmt.Sprintf("Parse %s for '%s=<url>', using the cloud-config served by an HTTP GET to <url>", proc_cmdline.ProcCmdlineLocation, proc_cmdline.ProcCmdlineCloudConfigFlag))
-	flag.BoolVar(&flags.sources.vmware, "from-vmware-backdoor", false, "Read data from VMware backdoor")
+	flag.BoolVar(&flags.sources.vmware, "from-vmware-guestinfo", false, "Read data from VMware guestinfo")
 	flag.StringVar(&flags.oem, "oem", "", "Use the settings specific to the provided OEM")
 	flag.StringVar(&flags.convertNetconf, "convert-netconf", "", "Read the network config provided in cloud-drive and translate it from the specified format into networkd unit files")
 	flag.StringVar(&flags.workspace, "workspace", "/var/lib/coreos-cloudinit", "Base directory coreos-cloudinit should use to store data")
@@ -121,7 +121,7 @@ var (
 			"from-packet-metadata": "https://metadata.packet.net/",
 		},
 		"vmware": oemConfig{
-			"from-vmware-backdoor": "true",
+			"from-vmware-guestinfo": "true",
 			"convert-netconf":      "vmware",
 		},
 	}
@@ -147,7 +147,7 @@ func main() {
 		for k := range oemConfigs {
 			oems = append(oems, k)
 		}
-		fmt.Printf("Invalid option to --oem: %q. Supported options: %q\n", flags.oem, oems)
+		fmt.Printf("Invalid option to -oem: %q. Supported options: %q\n", flags.oem, oems)
 		os.Exit(2)
 	}
 
@@ -169,7 +169,7 @@ func main() {
 
 	dss := getDatasources()
 	if len(dss) == 0 {
-		fmt.Println("Provide at least one of --from-file, --from-configdrive, --from-ec2-metadata, --from-cloudsigma-metadata, --from-packet-metadata, --from-vmware-backdoor, --from-digitalocean-metadata, --from-vmware-backdoor, --from-waagent, --from-url or --from-proc-cmdline")
+		fmt.Println("Provide at least one of -from-file, -from-configdrive, -from-ec2-metadata, -from-cloudsigma-metadata, -from-packet-metadata, -from-digitalocean-metadata, -from-vmware-guestinfo, -from-waagent, -from-url or -from-proc-cmdline")
 		os.Exit(2)
 	}
 


### PR DESCRIPTION
(Proposed) Based on results of google searches on a few possible titles
to improve on the connotation of backdoor, Guestinfo
Interface (part of the RPC API) seems recognizable in vmware
circles.

The flag to cloudinit changes with this to
`-from-vmware-guestinfo`.