### PR TITLE
Vmware-guestinfo: Double hyphen long options.

### DIFF
--- a/Documentation/vmware-guestinfo.md
+++ b/Documentation/vmware-guestinfo.md
@@ -3,7 +3,7 @@
 ## Cloud-Config VMWare Guestinfo Variables
 
 coreos-cloudinit accepts configuration from the VMware RPC API's *guestinfo*
-facility. This datasource can be enabled with the `-from-vmware-guestinfo`
+facility. This datasource can be enabled with the `--from-vmware-guestinfo`
 flag to coreos-cloudinit.
 
 The following guestinfo variables are recognized and processed by cloudinit

--- a/coreos-cloudinit.go
+++ b/coreos-cloudinit.go
@@ -169,7 +169,7 @@ func main() {
 
 	dss := getDatasources()
 	if len(dss) == 0 {
-		fmt.Println("Provide at least one of -from-file, -from-configdrive, -from-ec2-metadata, -from-cloudsigma-metadata, -from-packet-metadata, -from-digitalocean-metadata, -from-vmware-guestinfo, -from-waagent, -from-url or -from-proc-cmdline")
+		fmt.Println("Provide at least one of --from-file, --from-configdrive, --from-ec2-metadata, --from-cloudsigma-metadata, --from-packet-metadata, --from-digitalocean-metadata, --from-vmware-guestinfo, --from-waagent, --from-url or --from-proc-cmdline")
 		os.Exit(2)
 	}
 


### PR DESCRIPTION
In line with https://github.com/coreos/docs/issues/650,
revert a little bit of https://github.com/coreos/coreos-cloudinit/pull/404
to document `--longoption` with two hyphens in document and Usage.