### PR TITLE
Add After=system-config.target for user-cloudinit*

### DIFF
--- a/units/user-cloudinit-proc-cmdline.service
+++ b/units/user-cloudinit-proc-cmdline.service
@@ -2,6 +2,7 @@
 Description=Load cloud-config from url defined in /proc/cmdline
 Requires=coreos-setup-environment.service
 After=coreos-setup-environment.service
+After=system-config.target
 Before=user-config.target
 ConditionKernelCommandLine=cloud-config-url
 

--- a/units/user-cloudinit@.service
+++ b/units/user-cloudinit@.service
@@ -2,6 +2,7 @@
 Description=Load cloud-config from %f
 Requires=coreos-setup-environment.service
 After=coreos-setup-environment.service
+After=system-config.target
 Before=user-config.target
 ConditionFileNotEmpty=%f
 


### PR DESCRIPTION
This fix user-cloudinit-proc-cmdline.service being run at the same time as system-cloudinit@usr-share-oem-cloud\x2dconfig.yml.service on launch time.