### PR TITLE
Initial mime multipart support

### DIFF
--- a/Documentation/cloud-config.md
+++ b/Documentation/cloud-config.md
@@ -22,11 +22,14 @@ We've designed our implementation to allow the same cloud-config file to work ac
 [cloud-init-docs]: http://cloudinit.readthedocs.org/en/latest/index.html
 [cloud-config]: http://cloudinit.readthedocs.org/en/latest/topics/format.html#cloud-config-data
 
-### File Format
+### File Formats
 
-The cloud-config file uses the [YAML][yaml] file format, which uses whitespace and new-lines to delimit lists, associative arrays, and values.
+The configuration format comes in three flavors: cloud-config, shell script, and [MIME multipart mixed][MIME multipart mixed].
 
-A cloud-config file must contain a header: either `#cloud-config` for processing as cloud-config (suggested) or `#!` for processing as a shell script (advanced). If cloud-config has #cloud-config header, it should followed by an associative array which has zero or more of the following keys:
+#### Cloud-config
+The cloud-config format uses the [YAML][yaml] file format, which uses whitespace and new-lines to delimit lists, associative arrays, and values.
+
+A cloud-config formatted file must contain `#cloud-config` header as the first line for processing as cloud-config. Or if part of a MIME multipart document it must contain text/cloud-config as the content type. cloud-config data consists of an associative array which has zero or more of the following keys:
 
 - `coreos`
 - `ssh_authorized_keys`
@@ -35,11 +38,23 @@ A cloud-config file must contain a header: either `#cloud-config` for processing
 - `write_files`
 - `manage_etc_hosts`
 
-The expected values for these keys are defined in the rest of this document.
-
-If cloud-config header starts on `#!` then coreos-cloudinit will recognize it as shell script which is interpreted by bash and run it as transient systemd service.
-
 [yaml]: https://en.wikipedia.org/wiki/YAML
+[MIME multipart mixed]: https://en.wikipedia.org/wiki/MIME#Multipart_messages
+
+#### Shell Script
+
+The shell script format must contain a hashbang `#!` as its first line for processing as a shell script (advanced). Or if part of a MIME multipart mixed document it must contain text/x-shellscript as the content type.
+
+#### MIME Multipart Mixed
+
+The [MIME multipart mixed][MIME multipart mixed] format supports combining the above two formats as well as including configurations from external sources. This allows vendors to easily combine separate types of userdata from different sources, such as a user shell script and cloud-config section. If multiple cloud-config sections are specified, they will be merged in the order specified.
+
+The following MIME content types are supported:
+
+- `text/x-include-url` - The body should specify a URL or list of URLs. The URLs can point to shell scripts or cloud-config sections, which will be downloaded and processed accordingly.
+- `text/cloud-config` - The body is cloud-config data.
+- `text/x-shellscript` - The body will be executed as a shell script and must begin with a `#!`
+- `text/plain` - If the body is a cloud-config document starting with `#cloud-config` or a userdata script starting with `#!`, it will be processed as such. Otherwise, it will not be acted on.
 
 ### Providing Cloud-Config with Config-Drive
 

--- a/config/mime-multipart.go
+++ b/config/mime-multipart.go
@@ -1,0 +1,156 @@
+package config
+
+import (
+	"io"
+	"io/ioutil"
+	"mime"
+	"mime/multipart"
+	"net/mail"
+	"os"
+	"strings"
+
+	"github.com/coreos/coreos-cloudinit/pkg"
+)
+
+type MimeMultiPart struct {
+	Scripts []*Script
+	Configs []*CloudConfig
+}
+
+func (m *MimeMultiPart) AddScript(script []byte) error {
+	s, err := NewScript(string(script))
+	if err == nil {
+		m.Scripts = append(m.Scripts, s)
+	}
+	return err
+}
+
+func (m *MimeMultiPart) AddCloudConfig(config []byte) error {
+	c, err := NewCloudConfig(string(config))
+	if err == nil {
+		m.Configs = append(m.Configs, c)
+	}
+	return err
+}
+
+func (m *MimeMultiPart) AddMimeMultiPart(mmp []byte) error {
+	mm, err := NewMimeMultiPart(string(mmp))
+	if err == nil {
+		m.Config.Merge(mm.Config)
+		for _, script := range mm.Scripts {
+			if !m.scriptAlreadyExists(script) {
+				m.Scripts = append(m.Scripts, script)
+			}
+		}
+	}
+	return err
+}
+
+func (m *MimeMultiPart) scriptAlreadyExists(script *Script) bool {
+	for _, s := range m.Scripts {
+		if s == script {
+			return true
+		}
+	}
+	return false
+}
+
+func (m *MimeMultiPart) AddPlainText(pt []byte) error {
+	switch {
+	case IsScript(string(pt)):
+		return m.AddScript(pt)
+	case IsCloudConfig(string(pt)):
+		return m.AddCloudConfig(pt)
+	case IsMimeMultiPart(string(pt)):
+		return m.AddMimeMultiPart(pt)
+	}
+	return nil
+}
+
+func (m *MimeMultiPart) fileExists(file string) bool {
+	_, err := os.Stat(file)
+	return err == nil
+}
+
+func (m *MimeMultiPart) readUrl(url string) ([]byte, error) {
+	client := pkg.NewHttpClient()
+	return client.GetRetry(url)
+}
+
+func (m *MimeMultiPart) AddUrl(url string) error {
+	var err error
+	if data, err := m.readUrl(url); err == nil {
+		err = m.AddPlainText(data)
+	}
+	return err
+}
+
+func (m *MimeMultiPart) AddUrls(urls []byte) error {
+	var err error
+	for _, url := range strings.Split(string(urls), "\n") {
+		err = m.AddUrl(url)
+		if err != nil {
+			break
+		}
+	}
+	return err
+}
+
+func IsMimeMultiPart(userdata string) bool {
+	r := strings.NewReader(userdata)
+	m, err := mail.ReadMessage(r)
+	if err != nil {
+		return false
+	}
+	mediaType, _, err := mime.ParseMediaType(m.Header.Get("Content-Type"))
+	if err != nil {
+		return false
+	}
+	return strings.HasPrefix(mediaType, "multipart/")
+}
+
+func NewMimeMultiPart(content string) (*MimeMultiPart, error) {
+	var mmp MimeMultiPart
+
+	r := strings.NewReader(content)
+	m, err := mail.ReadMessage(r)
+	if err != nil {
+		return nil, err
+	}
+	mediaType, params, err := mime.ParseMediaType(m.Header.Get("Content-Type"))
+	if err != nil {
+		return nil, err
+	}
+	if strings.HasPrefix(mediaType, "multipart/") {
+		mr := multipart.NewReader(m.Body, params["boundary"])
+		for {
+			p, err := mr.NextPart()
+			if err == io.EOF {
+				break
+			}
+			if err != nil {
+				return nil, err
+			}
+			slurp, err := ioutil.ReadAll(p)
+			if err != nil {
+				return nil, err
+			}
+			switch p.Header.Get("Content-Type") {
+			case "text/x-shellscript":
+				err = mmp.AddScript(slurp)
+			case "text/cloud-config":
+				err = mmp.AddCloudConfig(slurp)
+			case "text/plain":
+				err = mmp.AddPlainText(slurp)
+			case "text/x-include-url":
+				err = mmp.AddUrls(slurp)
+			case "text/x-include-once-url":
+				err = mmp.AddUrls(slurp)
+			}
+			if err != nil {
+				return nil, err
+			}
+		}
+	}
+	return &mmp, nil
+}

--- a/config/mime-multipart.go
+++ b/config/mime-multipart.go
@@ -14,7 +14,7 @@ import (
 
 type MimeMultiPart struct {
 	Scripts []*Script
-	Configs []*CloudConfig
+	Config  *CloudConfig
 }
 
 func (m *MimeMultiPart) AddScript(script []byte) error {
@@ -28,7 +28,11 @@ func (m *MimeMultiPart) AddScript(script []byte) error {
 func (m *MimeMultiPart) AddCloudConfig(config []byte) error {
 	c, err := NewCloudConfig(string(config))
 	if err == nil {
-		m.Configs = append(m.Configs, c)
+		if m.Config == nil {
+			m.Config = c
+		} else {
+			m.Config.Merge(c)
+		}
 	}
 	return err
 }

--- a/config/mime-multipart_test.go
+++ b/config/mime-multipart_test.go
@@ -13,18 +13,13 @@ func sameMimeMultiParts(a, b MimeMultiPart) bool {
 	if len(a.Scripts) != len(b.Scripts) {
 		return false
 	}
-	if len(a.Configs) != len(b.Configs) {
-		return false
-	}
 	for i, _ := range a.Scripts {
 		if !bytes.Equal(*a.Scripts[i], *b.Scripts[i]) {
 			return false
 		}
 	}
-	for i, _ := range a.Configs {
-		if !reflect.DeepEqual(a.Configs[i], b.Configs[i]) {
-			return false
-		}
+	if !reflect.DeepEqual(a.Config, b.Config) {
+		return false
 	}
 	return true
 }
@@ -66,7 +61,7 @@ Content-Type: text/cloud-config
 %s
 --Boundary_ayn1dgbfbd03yc84am2azq--
 `, testScript, testConfig),
-			mmp: MimeMultiPart{Scripts: []*Script{t1}, Configs: []*CloudConfig{t2}},
+			mmp: MimeMultiPart{Scripts: []*Script{t1}, Config: t2},
 		},
 		{
 			contents: fmt.Sprintf(`Content-ID: <a4cdaxbfbd03yc84am2be4@ek4znmbfbd03yc84am2bfw.local>
@@ -85,7 +80,7 @@ Content-Type: text/cloud-config
 %s
 --Boundary_ayn1dgbfbd03yc84am2azq--
 `, testServer.URL, testConfig),
-			mmp: MimeMultiPart{Scripts: []*Script{t1}, Configs: []*CloudConfig{t2}},
+			mmp: MimeMultiPart{Scripts: []*Script{t1}, Config: t2},
 		},
 	}
 

--- a/config/mime-multipart_test.go
+++ b/config/mime-multipart_test.go
@@ -1,0 +1,101 @@
+package config
+
+import (
+	"bytes"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+)
+
+func sameMimeMultiParts(a, b MimeMultiPart) bool {
+	if len(a.Scripts) != len(b.Scripts) {
+		return false
+	}
+	if len(a.Configs) != len(b.Configs) {
+		return false
+	}
+	for i, _ := range a.Scripts {
+		if !bytes.Equal(*a.Scripts[i], *b.Scripts[i]) {
+			return false
+		}
+	}
+	for i, _ := range a.Configs {
+		if !reflect.DeepEqual(a.Configs[i], b.Configs[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+func TestNewMimeMultiPart(t *testing.T) {
+	testScript := `#! /bin/bash
+cat <<'EOF' >/var/lib/rightscale-identity
+account='67972'
+api_hostname='us-3.rightscale.com'
+client_id='18643426003'
+client_secret='a13bbcc595f773459fd9664da52480d2057d43e1'
+EOF
+chmod 0600 /var/lib/rightscale-identity`
+	testConfig := "#cloud-config\nwrite_files:\n  - permissions: 0744"
+	t1, _ := NewScript(testScript)
+	t2, _ := NewCloudConfig(testConfig)
+	testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(testScript))
+	}))
+
+	tests := []struct {
+		contents string
+		mmp      MimeMultiPart
+	}{
+		{
+			contents: fmt.Sprintf(`Content-ID: <a4cdaxbfbd03yc84am2be4@ek4znmbfbd03yc84am2bfw.local>
+Content-Type: multipart/mixed; boundary=Boundary_ayn1dgbfbd03yc84am2azq
+MIME-Version: 1.0
+
+--Boundary_ayn1dgbfbd03yc84am2azq
+Content-ID: <98w9o8bfbd03yc84am2cpg@a17vgbfbd03yc84am2cra.local>
+Content-Type: text/x-shellscript
+
+%s
+--Boundary_ayn1dgbfbd03yc84am2azq
+Content-ID: <c5vsnxbfbd03yc84am2cvy@cxx0y3bfbd03yc84am2cx6.local>
+Content-Type: text/cloud-config
+
+%s
+--Boundary_ayn1dgbfbd03yc84am2azq--
+`, testScript, testConfig),
+			mmp: MimeMultiPart{Scripts: []*Script{t1}, Configs: []*CloudConfig{t2}},
+		},
+		{
+			contents: fmt.Sprintf(`Content-ID: <a4cdaxbfbd03yc84am2be4@ek4znmbfbd03yc84am2bfw.local>
+Content-Type: multipart/mixed; boundary=Boundary_ayn1dgbfbd03yc84am2azq
+MIME-Version: 1.0
+
+--Boundary_ayn1dgbfbd03yc84am2azq
+Content-ID: <98w9o8bfbd03yc84am2cpg@a17vgbfbd03yc84am2cra.local>
+Content-Type: text/x-include-url
+
+%s
+--Boundary_ayn1dgbfbd03yc84am2azq
+Content-ID: <c5vsnxbfbd03yc84am2cvy@cxx0y3bfbd03yc84am2cx6.local>
+Content-Type: text/cloud-config
+
+%s
+--Boundary_ayn1dgbfbd03yc84am2azq--
+`, testServer.URL, testConfig),
+			mmp: MimeMultiPart{Scripts: []*Script{t1}, Configs: []*CloudConfig{t2}},
+		},
+	}
+
+	for i, tt := range tests {
+		mmp, err := NewMimeMultiPart(tt.contents)
+		if err != nil {
+			t.Errorf("bad error (test case #%d): want %v, got %s", i, nil, err)
+		}
+		if !sameMimeMultiParts(tt.mmp, *mmp) {
+			t.Errorf("bad mime-multipart (test case #%d): want %#v, got %#v", i, tt.mmp, mmp)
+		}
+	}
+}

--- a/config/unit.go
+++ b/config/unit.go
@@ -28,3 +28,20 @@ type UnitDropIn struct {
 	Name    string `yaml:"name"`
 	Content string `yaml:"content"`
 }
+
+func (u *Unit) Merge(mergeWith Unit) {
+	for _, dropIn := range mergeWith.DropIns {
+		if !u.dropInAlreadyExists(dropIn.Name) {
+			u.DropIns = append(u.DropIns, dropIn)
+		}
+	}
+}
+
+func (u *Unit) dropInAlreadyExists(dropInName string) bool {
+	for _, dropIn := range u.DropIns {
+		if dropIn.Name == dropInName {
+			return true
+		}
+	}
+	return false
+}

--- a/config/unit_test.go
+++ b/config/unit_test.go
@@ -17,6 +17,7 @@
 package config
 
 import (
+	"reflect"
 	"testing"
 )
 
@@ -41,6 +42,31 @@ func TestCommandValid(t *testing.T) {
 		isValid := (nil == AssertStructValid(Unit{Command: tt.value}))
 		if tt.isValid != isValid {
 			t.Errorf("bad assert (%s): want %t, got %t", tt.value, tt.isValid, isValid)
+		}
+	}
+}
+
+func TestUnitMerge(t *testing.T) {
+	tests := []struct {
+		inputs   []Unit
+		expected Unit
+	}{
+		{
+			inputs: []Unit{
+				Unit{DropIns: []UnitDropIn{UnitDropIn{Name: "unit1"}}},
+				Unit{DropIns: []UnitDropIn{UnitDropIn{Name: "unit2"}}},
+				Unit{DropIns: []UnitDropIn{UnitDropIn{Name: "unit1"}}},
+			},
+			expected: Unit{DropIns: []UnitDropIn{UnitDropIn{Name: "unit1"}, UnitDropIn{Name: "unit2"}}},
+		},
+	}
+	for i, tt := range tests {
+		u := tt.inputs[0]
+		for _, t := range tt.inputs[1:] {
+			u.Merge(t)
+		}
+		if !reflect.DeepEqual(tt.expected, u) {
+			t.Errorf("bad unit (test case #%d): want %#v, got %#v", i, tt.expected, u)
 		}
 	}
 }

--- a/config/user.go
+++ b/config/user.go
@@ -31,3 +31,48 @@ type User struct {
 	NoLogInit            bool     `yaml:"no_log_init"`
 	Shell                string   `yaml:"shell"`
 }
+
+func (u *User) Merge(mergeWith User) {
+	for _, key := range mergeWith.SSHAuthorizedKeys {
+		if !u.sshKeyAlreadyExists(key) {
+			u.SSHAuthorizedKeys = append(u.SSHAuthorizedKeys, key)
+		}
+	}
+	for _, user := range mergeWith.SSHImportGithubUsers {
+		if !u.sshImportGithubUserAlreadyExists(user) {
+			u.SSHImportGithubUsers = append(u.SSHImportGithubUsers, user)
+		}
+	}
+	for _, group := range mergeWith.Groups {
+		if !u.groupAlreadyExists(group) {
+			u.Groups = append(u.Groups, group)
+		}
+	}
+}
+
+func (u *User) sshKeyAlreadyExists(sshKey string) bool {
+	for _, key := range u.SSHAuthorizedKeys {
+		if key == sshKey {
+			return true
+		}
+	}
+	return false
+}
+
+func (u *User) sshImportGithubUserAlreadyExists(sshGithubUser string) bool {
+	for _, user := range u.SSHImportGithubUsers {
+		if user == sshGithubUser {
+			return true
+		}
+	}
+	return false
+}
+
+func (u *User) groupAlreadyExists(group string) bool {
+	for _, g := range u.Groups {
+		if g == group {
+			return true
+		}
+	}
+	return false
+}

--- a/config/user_test.go
+++ b/config/user_test.go
@@ -1,0 +1,56 @@
+// Copyright 2015 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestUserMerge(t *testing.T) {
+	tests := []struct {
+		inputs   []User
+		expected User
+	}{
+		{
+			inputs: []User{
+				User{Name: "user", SSHAuthorizedKeys: []string{"key1"}},
+				User{Name: "user", SSHAuthorizedKeys: []string{"key1", "key2"}},
+			},
+			expected: User{Name: "user", SSHAuthorizedKeys: []string{"key1", "key2"}},
+		},
+		{
+			inputs: []User{
+				User{Name: "user", SSHImportGithubUsers: []string{"github1"}},
+				User{Name: "user", SSHImportGithubUsers: []string{"github1", "github2"}},
+			},
+			expected: User{Name: "user", SSHImportGithubUsers: []string{"github1", "github2"}},
+		},
+		{
+			inputs: []User{
+				User{Name: "user", Groups: []string{"group1"}},
+				User{Name: "user", Groups: []string{"group1", "group2"}},
+			},
+			expected: User{Name: "user", Groups: []string{"group1", "group2"}},
+		},
+	}
+	for i, tt := range tests {
+		usr := tt.inputs[0]
+		usr.Merge(tt.inputs[1])
+		if !reflect.DeepEqual(tt.expected, usr) {
+			t.Errorf("bad user (test case #%d): want %#v, got %#v", i, tt.expected, usr)
+		}
+	}
+}

--- a/config/validate/validate.go
+++ b/config/validate/validate.go
@@ -42,11 +42,13 @@ func Validate(userdataBytes []byte) (Report, error) {
 		return Report{}, nil
 	case config.IsIgnitionConfig(string(userdataBytes)):
 		return Report{}, nil
+	case config.IsMimeMultiPart(string(userdataBytes)):
+		return Report{}, nil
 	case config.IsCloudConfig(string(userdataBytes)):
 		return validateCloudConfig(userdataBytes, Rules)
 	default:
 		return Report{entries: []Entry{
-			Entry{kind: entryError, message: `must be "#cloud-config" or begin with "#!"`, line: 1},
+			Entry{kind: entryError, message: `must be "#cloud-config" or begin with "#!" or be mime-multipart`, line: 1},
 		}}, nil
 	}
 }

--- a/config/validate/validate_test.go
+++ b/config/validate/validate_test.go
@@ -113,7 +113,7 @@ func TestValidate(t *testing.T) {
 		},
 		{
 			config: "{}",
-			report: Report{entries: []Entry{{entryError, `must be "#cloud-config" or begin with "#!"`, 1}}},
+			report: Report{entries: []Entry{{entryError, `must be "#cloud-config" or begin with "#!" or be mime-multipart`, 1}}},
 		},
 		{
 			config: `{"ignitionVersion":0}`,

--- a/initialize/user_data.go
+++ b/initialize/user_data.go
@@ -39,6 +39,8 @@ func ParseUserData(contents string) (interface{}, error) {
 		return config.NewCloudConfig(contents)
 	case config.IsIgnitionConfig(contents):
 		return nil, ErrIgnitionConfig
+	case config.IsMimeMultiPart(contents):
+		return config.NewMimeMultiPart(contents)
 	default:
 		return nil, errors.New("Unrecognized user-data format")
 	}


### PR DESCRIPTION
The mime-multipart format supports combining shell scripts and cloud
configs as well as including configurations from external sources.
This allows vendors to easily combine separate types of userdata
from different sources, such as a user shell script and cloud-config section.

Addresses coreos/bugs#912.