### PR TITLE
add support for media/images with UDF filesystem

### DIFF
--- a/units/90-configdrive.rules
+++ b/units/90-configdrive.rules
@@ -3,7 +3,7 @@
 ACTION!="add|change", GOTO="coreos_configdrive_end"
 
 # A normal config drive. Block device formatted with iso9660 or fat
-SUBSYSTEM=="block", ENV{ID_FS_TYPE}=="iso9660|vfat", ENV{ID_FS_LABEL}=="config-2", TAG+="systemd", ENV{SYSTEMD_WANTS}+="media-configdrive.mount"
+SUBSYSTEM=="block", ENV{ID_FS_TYPE}=="iso9660|udf|vfat", ENV{ID_FS_LABEL}=="config-2", TAG+="systemd", ENV{SYSTEMD_WANTS}+="media-configdrive.mount"
 
 # Addtionally support virtfs from QEMU
 SUBSYSTEM=="virtio", DRIVER=="9pnet_virtio", ATTR{mount_tag}=="config-2", TAG+="systemd", ENV{SYSTEMD_WANTS}+="media-configvirtfs.mount"


### PR DESCRIPTION
CDROM media or ISO image might also contain UDF (ISO/IEC 13346) file system which should be support as well.