### PR TITLE
units: remove user-config-ovfenv.path

### DIFF
--- a/units/user-config.target
+++ b/units/user-config.target
@@ -11,6 +11,3 @@ After=user-cloudinit@var-lib-coreos\x2dinstall-user_data.path
 
 Requires=user-cloudinit-proc-cmdline.service
 After=user-cloudinit-proc-cmdline.service
-
-Requires=user-config-ovfenv.path
-After=user-config-ovfenv.path


### PR DESCRIPTION
This unit doesn't actually exist. user-config-ovfenv.service is triggered by
media-ovfenv.mount so we don't need the path anyway.