### PR TITLE
config: add decoding support for cloud init template write_files section

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -68,6 +68,22 @@ func NewCloudConfig(contents string) (*CloudConfig, error) {
 	return &cfg, err
 }
 
+// Decode decodes the content of cloud config. Currently only WriteFiles section
+// supports several types of encoding and all of them are supported. After
+// decode operation, Encoding type is unset.
+func (cc *CloudConfig) Decode() error {
+	for i, file := range cc.WriteFiles {
+		content, err := DecodeContent(file.Content, file.Encoding)
+		if err != nil {
+			return err
+		}
+
+		cc.WriteFiles[i].Content = string(content)
+		cc.WriteFiles[i].Encoding = ""
+	}
+
+	return nil
+}
 func (cc CloudConfig) String() string {
 	bytes, err := yaml.Marshal(cc)
 	if err != nil {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -15,6 +15,7 @@
 package config
 
 import (
+	"fmt"
 	"reflect"
 	"regexp"
 	"strings"
@@ -71,6 +72,50 @@ func TestNewCloudConfig(t *testing.T) {
 			t.Errorf("bad config (test case #%d): want %#v, got %#v", i, tt.config, config)
 		}
 	}
+}
+
+func TestNewCloudConfigDecode(t *testing.T) {
+	// //all of these decode to "bar"
+	contentTests := map[string]string{
+		"base64": "YmFy",
+		"b64":    "YmFy",
+		// theoretically gz+gzip are supported but they break yaml
+		// "gz":          "\x1f\x8b\x08\x08w\x14\x87T\x02\xffok\x00KJ,\x02\x00\xaa\x8c\xffv\x03\x00\x00\x00",
+		// "gzip":        "\x1f\x8b\x08\x08w\x14\x87T\x02\xffok\x00KJ,\x02\x00\xaa\x8c\xffv\x03\x00\x00\x00",
+		"gz+base64":   "H4sIABMVh1QAA0tKLAIAqoz/dgMAAAA=",
+		"gzip+base64": "H4sIABMVh1QAA0tKLAIAqoz/dgMAAAA=",
+		"gz+b64":      "H4sIABMVh1QAA0tKLAIAqoz/dgMAAAA=",
+		"gzip+b64":    "H4sIABMVh1QAA0tKLAIAqoz/dgMAAAA=",
+	}
+
+	type testCase struct {
+		contents string
+		config   CloudConfig
+	}
+
+	var decodingTests []testCase
+	for name, content := range contentTests {
+		decodingTests = append(decodingTests, testCase{
+			contents: fmt.Sprintf("#cloud-config\nwrite_files:\n  - encoding: %q\n    content: |\n      %s", name, content),
+			config:   CloudConfig{WriteFiles: []File{{Content: "bar"}}},
+		})
+	}
+
+	for i, tt := range decodingTests {
+		config, err := NewCloudConfig(tt.contents)
+		if err != nil {
+			t.Errorf("bad error (test case #%d): want %v, got %s", i, nil, err)
+		}
+
+		if err := config.Decode(); err != nil {
+			t.Errorf("bad error (test case #%d): want %v, got %s", i, nil, err)
+		}
+
+		if !reflect.DeepEqual(&tt.config, config) {
+			t.Errorf("bad config (test case #%d): want %#v, got %#v", i, tt.config, config)
+		}
+	}
+
 }
 
 func TestIsZero(t *testing.T) {

--- a/initialize/user_data.go
+++ b/initialize/user_data.go
@@ -36,7 +36,16 @@ func ParseUserData(contents string) (interface{}, error) {
 		return config.NewScript(contents)
 	case config.IsCloudConfig(contents):
 		log.Printf("Parsing user-data as cloud-config")
-		return config.NewCloudConfig(contents)
+		cc, err := config.NewCloudConfig(contents)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := cc.Decode(); err != nil {
+			return nil, err
+		}
+
+		return cc, nil
 	case config.IsIgnitionConfig(contents):
 		return nil, ErrIgnitionConfig
 	default:

--- a/system/file.go
+++ b/system/file.go
@@ -45,16 +45,15 @@ func (f *File) Permissions() (os.FileMode, error) {
 	return os.FileMode(perm), nil
 }
 
+// WriteFile writes given endecoded file to the filesystem
 func WriteFile(f *File, root string) (string, error) {
+	if f.Encoding != "" {
+		return "", fmt.Errorf("Unable to write file with encoding %s", f.Encoding)
+	}
+
 	fullpath := path.Join(root, f.Path)
 	dir := path.Dir(fullpath)
 	log.Printf("Writing file to %q", fullpath)
-
-	content, err := config.DecodeContent(f.Content, f.Encoding)
-
-	if err != nil {
-		return "", fmt.Errorf("Unable to decode %s (%v)", f.Path, err)
-	}
 
 	if err := EnsureDirectoryExists(dir); err != nil {
 		return "", err
@@ -71,7 +70,7 @@ func WriteFile(f *File, root string) (string, error) {
 		return "", err
 	}
 
-	if err := ioutil.WriteFile(tmp.Name(), content, perm); err != nil {
+	if err := ioutil.WriteFile(tmp.Name(), []byte(f.Content), perm); err != nil {
 		return "", err
 	}
 

--- a/system/file_test.go
+++ b/system/file_test.go
@@ -147,62 +147,6 @@ func TestWriteFilePermissions(t *testing.T) {
 	}
 }
 
-func TestWriteFileEncodedContent(t *testing.T) {
-	dir, err := ioutil.TempDir(os.TempDir(), "coreos-cloudinit-")
-	if err != nil {
-		t.Fatalf("Unable to create tempdir: %v", err)
-	}
-	defer os.RemoveAll(dir)
-
-	//all of these decode to "bar"
-	content_tests := map[string]string{
-		"base64":      "YmFy",
-		"b64":         "YmFy",
-		"gz":          "\x1f\x8b\x08\x08w\x14\x87T\x02\xffok\x00KJ,\x02\x00\xaa\x8c\xffv\x03\x00\x00\x00",
-		"gzip":        "\x1f\x8b\x08\x08w\x14\x87T\x02\xffok\x00KJ,\x02\x00\xaa\x8c\xffv\x03\x00\x00\x00",
-		"gz+base64":   "H4sIABMVh1QAA0tKLAIAqoz/dgMAAAA=",
-		"gzip+base64": "H4sIABMVh1QAA0tKLAIAqoz/dgMAAAA=",
-		"gz+b64":      "H4sIABMVh1QAA0tKLAIAqoz/dgMAAAA=",
-		"gzip+b64":    "H4sIABMVh1QAA0tKLAIAqoz/dgMAAAA=",
-	}
-
-	for encoding, content := range content_tests {
-		fullPath := path.Join(dir, encoding)
-
-		wf := File{config.File{
-			Path:               encoding,
-			Encoding:           encoding,
-			Content:            content,
-			RawFilePermissions: "0644",
-		}}
-
-		path, err := WriteFile(&wf, dir)
-		if err != nil {
-			t.Fatalf("Processing of WriteFile failed: %v", err)
-		} else if path != fullPath {
-			t.Fatalf("WriteFile returned bad path: want %s, got %s", fullPath, path)
-		}
-
-		fi, err := os.Stat(fullPath)
-		if err != nil {
-			t.Fatalf("Unable to stat file: %v", err)
-		}
-
-		if fi.Mode() != os.FileMode(0644) {
-			t.Errorf("File has incorrect mode: %v", fi.Mode())
-		}
-
-		contents, err := ioutil.ReadFile(fullPath)
-		if err != nil {
-			t.Fatalf("Unable to read expected file: %v", err)
-		}
-
-		if string(contents) != "bar" {
-			t.Fatalf("File has incorrect contents: '%s'", contents)
-		}
-	}
-}
-
 func TestWriteFileInvalidEncodedContent(t *testing.T) {
 	dir, err := ioutil.TempDir(os.TempDir(), "coreos-cloudinit-")
 	if err != nil {


### PR DESCRIPTION
Decoding of a gzipped cloud init template is already supported, but when it comes to write-files if  the content is encoded with a some format, decode operation does not applied to them. Currently only write-files section support encoding type, so do the transformation while initializing the cloud init template.

WriteFile also does the transformation if the encoding type is set. CloudConfig.Decode unsets it.