### PR TITLE
datasource: set unqualified hostname from ec2 metadata

### DIFF
--- a/datasource/metadata/ec2/metadata.go
+++ b/datasource/metadata/ec2/metadata.go
@@ -69,7 +69,7 @@ func (ms metadataService) FetchMetadata() (datasource.Metadata, error) {
 	}
 
 	if hostname, err := ms.fetchAttribute(fmt.Sprintf("%s/hostname", ms.MetadataUrl())); err == nil {
-		metadata.Hostname = strings.Split(hostname, " ")[0]
+		metadata.Hostname = strings.Split(strings.Split(hostname, " ")[0], ".")[0]
 	} else if _, ok := err.(pkg.ErrNotFound); !ok {
 		return metadata, err
 	}

--- a/datasource/metadata/ec2/metadata_test.go
+++ b/datasource/metadata/ec2/metadata_test.go
@@ -195,6 +195,24 @@ func TestFetchMetadata(t *testing.T) {
 			},
 		},
 		{
+			root:         "/",
+			metadataPath: "2009-04-04/meta-data",
+			resources: map[string]string{
+				"/2009-04-04/meta-data/hostname":                  "host.private.domain. domain another_domain",
+				"/2009-04-04/meta-data/local-ipv4":                "1.2.3.4",
+				"/2009-04-04/meta-data/public-ipv4":               "5.6.7.8",
+				"/2009-04-04/meta-data/public-keys":               "0=test1\n",
+				"/2009-04-04/meta-data/public-keys/0":             "openssh-key",
+				"/2009-04-04/meta-data/public-keys/0/openssh-key": "key",
+			},
+			expect: datasource.Metadata{
+				Hostname:      "host",
+				PrivateIPv4:   net.ParseIP("1.2.3.4"),
+				PublicIPv4:    net.ParseIP("5.6.7.8"),
+				SSHPublicKeys: map[string]string{"test1": "key"},
+			},
+		},
+		{
 			clientErr: pkg.ErrTimeout{Err: fmt.Errorf("test error")},
 			expectErr: pkg.ErrTimeout{Err: fmt.Errorf("test error")},
 		},


### PR DESCRIPTION
The EC2 hostname metadata http://169.254.169.254/latest/meta-data/hostname
returns a fully qualified hostname in case of a VPC with a
private hosted zone, resulting in DNS lookup failures for these machine
names.

Fixes https://github.com/coreos/bugs/issues/1272.