### PR TITLE
Remove Author from Unit

### DIFF
--- a/Documentation/cloud-config.md
+++ b/Documentation/cloud-config.md
@@ -293,7 +293,6 @@ coreos:
       content: |
         [Unit]
         Description=Redis container
-        Author=Me
         After=docker.service
 
         [Service]


### PR DESCRIPTION
coreos.units seem to be systemd units. However, lvalue Author cannot be
found at:
https://www.freedesktop.org/software/systemd/man/systemd.service.html

systemd refuses to start the service in its current form.
