### PR TITLE
Return the error instead of logging it to keep consistent

### DIFF
--- a/system/user.go
+++ b/system/user.go
@@ -95,7 +95,7 @@ func SetUserPassword(user, hash string) error {
 
 	err = cmd.Start()
 	if err != nil {
-		log.Fatal(err)
+		return err
 	}
 
 	arg := fmt.Sprintf("%s:%s", user, hash)


### PR DESCRIPTION
Errors are returned everywhere in SetUserPassword` except for this one spot which just logs the error. I believe the intention is to return here.