### PR TITLE
Enable multicore support

### DIFF
--- a/coreos-cloudinit.go
+++ b/coreos-cloudinit.go
@@ -22,7 +22,6 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
-	"runtime"
 	"sync"
 	"time"
 

--- a/coreos-cloudinit.go
+++ b/coreos-cloudinit.go
@@ -141,12 +141,6 @@ var (
 func main() {
 	failure := false
 
-	// Conservative Go 1.5 upgrade strategy:
-	// keep GOMAXPROCS' default at 1 for now.
-	if os.Getenv("GOMAXPROCS") == "" {
-		runtime.GOMAXPROCS(1)
-	}
-
 	flag.Parse()
 
 	if c, ok := oemConfigs[flags.oem]; ok {


### PR DESCRIPTION
Now that we're approaching Go 1.7 (hopefully released this week) and the language default for `GOMAXPROCS` has been the number of cores in a system for a while now, I figured it'd make sense to remove this restriction.