### PR TITLE
docs: lead with link to vmware docs

### DIFF
--- a/Documentation/vmware-guestinfo.md
+++ b/Documentation/vmware-guestinfo.md
@@ -1,5 +1,8 @@
 # VMWare Guestinfo Interface
 
+The guide to [booting on VMWare][bootvmware] is the starting point for more
+information about configuring and running CoreOS on VMWare. To programatically configure your CoreOS VMs running with VMware, read on below.
+
 ## Cloud-Config VMWare Guestinfo Variables
 
 coreos-cloudinit accepts configuration from the VMware RPC API's *guestinfo*
@@ -28,8 +31,5 @@ property names are prefixed with `guestinfo.` in the VMX, e.g., `guestinfo.hostn
 Note: "n", "m", "l", and "x" are 0-indexed, incrementing integers. The
 identifier for an `interface` does not correspond to anything outside of this
 configuration; it serves only to distinguish between multiple `interface`s.
-
-The guide to [booting on VMWare][bootvmware] is the starting point for more
-information about configuring and running CoreOS on VMWare.
 
 [bootvmware]: https://github.com/coreos/docs/blob/master/os/booting-on-vmware.md


### PR DESCRIPTION
I wish on coreos.com/os/docs/latest/vmware-guestinfo.html

> I wish this page contained example code

Reading into this one a bit, I don't think this doc gives you the background for where/how to run these commands.

This PR moves the link to the VMware docs up to the top.