### PR TITLE
main: add flags for digitalocean-ignition

### DIFF
--- a/coreos-cloudinit.go
+++ b/coreos-cloudinit.go
@@ -107,6 +107,10 @@ type oemConfig map[string]string
 
 var (
 	oemConfigs = map[string]oemConfig{
+		"digitalocean-ignition": {
+			"from-file":       "/dev/null",
+			"convert-netconf": "digitalocean",
+		},
 		"digitalocean": {
 			"from-digitalocean-metadata": "http://169.254.169.254/",
 			"convert-netconf":            "digitalocean",


### PR DESCRIPTION
The purpose of this OEM is to configure the network interfaces without
applying any user config. It's intended to be used by Ignition to
configure the network on boot.