### PR TITLE
units: add timeout to all services

### DIFF
--- a/units/system-cloudinit@.service
+++ b/units/system-cloudinit@.service
@@ -7,5 +7,6 @@ ConditionFileNotEmpty=%f
 
 [Service]
 Type=oneshot
+TimeoutSec=10min
 RemainAfterExit=yes
 ExecStart=/usr/bin/coreos-cloudinit --from-file=%f

--- a/units/user-cloudinit-proc-cmdline.service
+++ b/units/user-cloudinit-proc-cmdline.service
@@ -8,6 +8,7 @@ ConditionKernelCommandLine=cloud-config-url
 
 [Service]
 Type=oneshot
+TimeoutSec=10min
 RemainAfterExit=yes
 EnvironmentFile=-/etc/environment
 ExecStart=/usr/bin/coreos-cloudinit --from-proc-cmdline

--- a/units/user-cloudinit@.service
+++ b/units/user-cloudinit@.service
@@ -8,6 +8,7 @@ ConditionFileNotEmpty=%f
 
 [Service]
 Type=oneshot
+TimeoutSec=10min
 RemainAfterExit=yes
 EnvironmentFile=-/etc/environment
 ExecStart=/usr/bin/coreos-cloudinit --from-file=%f

--- a/units/user-config-ovfenv.service
+++ b/units/user-config-ovfenv.service
@@ -7,6 +7,7 @@ After=user-config-vmw-tools.service
 
 [Service]
 Type=oneshot
+TimeoutSec=10min
 RemainAfterExit=yes
 EnvironmentFile=-/etc/environment
 ExecStart=/usr/bin/coreos-cloudinit --from-vmware-ovf-env=/media/ovfenv/ovf-env.xml

--- a/units/user-configdrive.service
+++ b/units/user-configdrive.service
@@ -17,6 +17,7 @@ After=oem-cloudinit.service
 
 [Service]
 Type=oneshot
+TimeoutSec=10min
 RemainAfterExit=yes
 EnvironmentFile=-/etc/environment
 ExecStart=/usr/bin/coreos-cloudinit --from-configdrive=/media/configdrive

--- a/units/user-configvirtfs.service
+++ b/units/user-configvirtfs.service
@@ -6,6 +6,7 @@ Before=user-config.target
 
 [Service]
 Type=oneshot
+TimeoutSec=10min
 RemainAfterExit=yes
 EnvironmentFile=-/etc/environment
 ExecStart=/usr/bin/coreos-cloudinit --from-configdrive=/media/configvirtfs


### PR DESCRIPTION
Since coreos-cloudinit's internal service scheduling is opaque to
systemd and doesn't handle dependency-loop detection, it is possible for
it to cause deadlocks. Introducing the timeout to all invocations
provides a mechanism for system to regain control of the startup
sequence.