### PR TITLE
build: fix missing = in GLDFLAGS

### DIFF
--- a/build
+++ b/build
@@ -4,7 +4,7 @@ NAME="coreos-cloudinit"
 ORG_PATH="github.com/coreos"
 REPO_PATH="${ORG_PATH}/${NAME}"
 VERSION=$(git describe --dirty --tags)
-GLDFLAGS="-X main.version \"${VERSION}\""
+GLDFLAGS="-X main.version=\"${VERSION}\""
 
 if [ ! -h gopath/src/${REPO_PATH} ]; then
 	mkdir -p gopath/src/${ORG_PATH}


### PR DESCRIPTION
build: fix missing = in GLDFLAGS

The -X option requires = rather than space.  
