### PR TITLE
docs: deprecate etcd2 config section

### DIFF
--- a/Documentation/cloud-config.md
+++ b/Documentation/cloud-config.md
@@ -21,7 +21,7 @@ It will show `coreos-cloudinit` run output which was triggered by system boot.
 
 ## Configuration File
 
-The file used by this system initialization program is called a "cloud-config" file. It is inspired by the [cloud-init][cloud-init] project's [cloud-config][cloud-config] file, which is "the defacto multi-distribution package that handles early initialization of a cloud instance" ([cloud-init docs][cloud-init-docs]). Because the cloud-init project includes tools which aren't used by CoreOS, only the relevant subset of its configuration items will be implemented in our cloud-config file. In addition to those, we added a few CoreOS-specific items, such as etcd configuration, OEM definition, and systemd units.
+The file used by this system initialization program is called a "cloud-config" file. It is inspired by the [cloud-init][cloud-init] project's [cloud-config][cloud-config] file, which is "the defacto multi-distribution package that handles early initialization of a cloud instance" ([cloud-init docs][cloud-init-docs]). Because the cloud-init project includes tools which aren't used by CoreOS, only the relevant subset of its configuration items will be implemented in our cloud-config file. In addition to those, we added a few CoreOS-specific items, such as etcd configuration (deprecated), OEM definition, and systemd units.
 
 We've designed our implementation to allow the same cloud-config file to work across all of our supported platforms.
 
@@ -56,7 +56,7 @@ CoreOS tries to conform to each platform's native method to provide user data. E
 
 ### coreos
 
-#### etcd (deprecated. see etcd2)
+#### etcd (deprecated)
 
 The `coreos.etcd.*` parameters will be translated to a partial systemd unit acting as an etcd configuration file.
 If the platform environment supports the templating feature of coreos-cloudinit it is possible to automate etcd configuration with the `$private_ipv4` and `$public_ipv4` fields. For example, the following cloud-config document...
@@ -90,7 +90,7 @@ _Note: The `$private_ipv4` and `$public_ipv4` substitution variables referenced 
 
 [etcd-config]: https://github.com/coreos/etcd/blob/release-0.4/Documentation/configuration.md
 
-#### etcd2
+#### etcd2 (deprecated)
 
 The `coreos.etcd2.*` parameters will be translated to a partial systemd unit acting as an etcd configuration file.
 If the platform environment supports the templating feature of coreos-cloudinit it is possible to automate etcd configuration with the `$private_ipv4` and `$public_ipv4` fields. When generating a [discovery token](https://discovery.etcd.io/new?size=3), set the `size` parameter, since etcd uses this to determine if all members have joined the cluster. After the cluster is bootstrapped, it can grow or shrink from this configured size.

--- a/config/config.go
+++ b/config/config.go
@@ -37,10 +37,10 @@ type CloudConfig struct {
 }
 
 type CoreOS struct {
-	Etcd      Etcd      `yaml:"etcd"`
-	Etcd2     Etcd2     `yaml:"etcd2"`
+	Etcd      Etcd      `yaml:"etcd"      deprecated:"etcd is no longer shipped in Container Linux"`
+	Etcd2     Etcd2     `yaml:"etcd2"     deprecated:"etcd2 will soon be removed from Container Linux"`
 	Flannel   Flannel   `yaml:"flannel"`
-	Fleet     Fleet     `yaml:"fleet"`
+	Fleet     Fleet     `yaml:"fleet"     deprecated:"fleet is no longer shipped in Container Linux"`
 	Locksmith Locksmith `yaml:"locksmith"`
 	OEM       OEM       `yaml:"oem"`
 	Update    Update    `yaml:"update"`

--- a/config/validate/rules_test.go
+++ b/config/validate/rules_test.go
@@ -112,20 +112,17 @@ func TestCheckStructure(t *testing.T) {
 			entries: []Entry{{entryWarning, "unrecognized key \"test\"", 1}},
 		},
 		{
-			config:  "coreos:\n  etcd:\n    bad:",
+			config:  "coreos:\n  flannel:\n    bad:",
 			entries: []Entry{{entryWarning, "unrecognized key \"bad\"", 3}},
 		},
 		{
-			config: "coreos:\n  etcd:\n    discovery: good",
+			config: "coreos:\n  flannel:\n    interface: good",
 		},
 
 		// Test for deprecated keys
 		{
-			config: "coreos:\n  etcd:\n    addr: hi",
-		},
-		{
 			config:  "coreos:\n  etcd:\n    proxy: hi",
-			entries: []Entry{{entryWarning, "deprecated key \"proxy\" (etcd2 options no longer work for etcd)", 3}},
+			entries: []Entry{{entryWarning, "deprecated key \"etcd\" (etcd is no longer shipped in Container Linux)", 2}, {entryWarning, "deprecated key \"proxy\" (etcd2 options no longer work for etcd)", 3}},
 		},
 
 		// Test for error on list of nodes
@@ -188,9 +185,6 @@ func TestCheckStructure(t *testing.T) {
 		{
 			config:  "coreos: hello",
 			entries: []Entry{{entryWarning, "incorrect type for \"coreos\" (want struct)", 1}},
-		},
-		{
-			config: "coreos:\n  etcd:\n    discovery: fire in the disco",
 		},
 		{
 			config:  "coreos:\n  - hello",


### PR DESCRIPTION
etcd2 will be removed from Container Linux in early 2018.