### PR TITLE
*: remove locksmith "best effort" strategy

### DIFF
--- a/Documentation/cloud-config.md
+++ b/Documentation/cloud-config.md
@@ -253,10 +253,9 @@ The `coreos.update.*` parameters manipulate settings related to how CoreOS insta
 These fields will be written out to and replace `/etc/coreos/update.conf`. If only one of the parameters is given it will only overwrite the given field.
 The `reboot-strategy` parameter also affects the behaviour of [locksmith](https://github.com/coreos/locksmith).
 
-- **reboot-strategy**: One of "reboot", "etcd-lock", "best-effort" or "off" for controlling when reboots are issued after an update is performed.
+- **reboot-strategy**: One of "reboot", "etcd-lock", or "off" for controlling when reboots are issued after an update is performed.
   - _reboot_: Reboot immediately after an update is applied.
   - _etcd-lock_: Reboot after first taking a distributed lock in etcd, this guarantees that only one host will reboot concurrently and that the cluster will remain available during the update.
-  - _best-effort_ - If etcd is running, "etcd-lock", otherwise simply "reboot".
   - _off_ - Disable rebooting after updates are applied (not recommended).
 - **server**: The location of the [CoreUpdate][coreupdate] server which will be queried for updates. Also known as the [omaha][omaha-docs] server endpoint.
 - **group**:  signifies the channel which should be used for automatic updates.  This value defaults to the version of the image initially downloaded. (one of "master", "alpha", "beta", "stable")

--- a/config/update.go
+++ b/config/update.go
@@ -15,7 +15,7 @@
 package config
 
 type Update struct {
-	RebootStrategy string `yaml:"reboot_strategy" env:"REBOOT_STRATEGY" valid:"^(best-effort|etcd-lock|reboot|off)$"`
+	RebootStrategy string `yaml:"reboot_strategy" env:"REBOOT_STRATEGY" valid:"^(etcd-lock|reboot|off)$"`
 	Group          string `yaml:"group"           env:"GROUP"`
 	Server         string `yaml:"server"          env:"SERVER"`
 }

--- a/config/update_test.go
+++ b/config/update_test.go
@@ -26,7 +26,6 @@ func TestRebootStrategyValid(t *testing.T) {
 
 		isValid bool
 	}{
-		{value: "best-effort", isValid: true},
 		{value: "etcd-lock", isValid: true},
 		{value: "reboot", isValid: true},
 		{value: "off", isValid: true},

--- a/pkg/http_client_test.go
+++ b/pkg/http_client_test.go
@@ -112,7 +112,7 @@ coreos:
 	    home-url: https://github.com/coreos/coreos-cloudinit
 	    bug-report-url: https://github.com/coreos/coreos-cloudinit
 	update:
-		reboot-strategy: best-effort
+		reboot-strategy: etcd-lock
 `
 
 	client := NewHttpClient()

--- a/system/update_test.go
+++ b/system/update_test.go
@@ -46,14 +46,6 @@ func TestUpdateUnits(t *testing.T) {
 			}}},
 		},
 		{
-			config: config.Update{RebootStrategy: "best-effort"},
-			units: []Unit{{config.Unit{
-				Name:    "locksmithd.service",
-				Command: "restart",
-				Runtime: true,
-			}}},
-		},
-		{
 			config: config.Update{RebootStrategy: "etcd-lock"},
 			units: []Unit{{config.Unit{
 				Name:    "locksmithd.service",
@@ -98,20 +90,12 @@ func TestUpdateFile(t *testing.T) {
 		},
 		{
 			config: config.Update{RebootStrategy: "wizzlewazzle"},
-			err:    &config.ErrorValid{Value: "wizzlewazzle", Field: "RebootStrategy", Valid: "^(best-effort|etcd-lock|reboot|off)$"},
+			err:    &config.ErrorValid{Value: "wizzlewazzle", Field: "RebootStrategy", Valid: "^(etcd-lock|reboot|off)$"},
 		},
 		{
 			config: config.Update{Group: "master", Server: "http://foo.com"},
 			file: &File{config.File{
 				Content:            "GROUP=master\nSERVER=http://foo.com\n",
-				Path:               "etc/coreos/update.conf",
-				RawFilePermissions: "0644",
-			}},
-		},
-		{
-			config: config.Update{RebootStrategy: "best-effort"},
-			file: &File{config.File{
-				Content:            "REBOOT_STRATEGY=best-effort\n",
 				Path:               "etc/coreos/update.conf",
 				RawFilePermissions: "0644",
 			}},


### PR DESCRIPTION
Removes all mention of the "best effort" locksmith strategy from documentation, tests, and strategies accepted during validation.

Fixes https://github.com/coreos/coreos-cloudinit/pull/451