### PR TITLE
config: etcd2 is no longer shipped, update warning

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -38,7 +38,7 @@ type CloudConfig struct {
 
 type CoreOS struct {
 	Etcd      Etcd      `yaml:"etcd"      deprecated:"etcd is no longer shipped in Container Linux"`
-	Etcd2     Etcd2     `yaml:"etcd2"     deprecated:"etcd2 will soon be removed from Container Linux"`
+	Etcd2     Etcd2     `yaml:"etcd2"     deprecated:"etcd2 is no longer shipped in Container Linux"`
 	Flannel   Flannel   `yaml:"flannel"`
 	Fleet     Fleet     `yaml:"fleet"     deprecated:"fleet is no longer shipped in Container Linux"`
 	Locksmith Locksmith `yaml:"locksmith"`


### PR DESCRIPTION
Update the deprecation warning for the etcd2 section to inform the user
that etcd2 is no longer shipped with Container Linux