### PR TITLE
config: use LOCKSMITHD_ prefixed environment variables

### DIFF
--- a/config/locksmith.go
+++ b/config/locksmith.go
@@ -22,6 +22,6 @@ type Locksmith struct {
 	EtcdUsername       string `yaml:"etcd_username" env:"LOCKSMITHD_ETCD_USERNAME"`
 	EtcdPassword       string `yaml:"etcd_password" env:"LOCKSMITHD_ETCD_PASSWORD"`
 	Group              string `yaml:"group"         env:"LOCKSMITHD_GROUP"`
-	RebootWindowStart  string `yaml:"window_start"  env:"REBOOT_WINDOW_START"  valid:"^((?i:sun|mon|tue|wed|thu|fri|sat|sun) )?0*([0-9]|1[0-9]|2[0-3]):0*([0-9]|[1-5][0-9])$"`
-	RebootWindowLength string `yaml:"window_length" env:"REBOOT_WINDOW_LENGTH" valid:"^[-+]?([0-9]*(\\.[0-9]*)?[a-z]+)+$"`
+	RebootWindowStart  string `yaml:"window_start"  env:"LOCKSMITHD_REBOOT_WINDOW_START"  valid:"^((?i:sun|mon|tue|wed|thu|fri|sat|sun) )?0*([0-9]|1[0-9]|2[0-3]):0*([0-9]|[1-5][0-9])$"`
+	RebootWindowLength string `yaml:"window_length" env:"LOCKSMITHD_REBOOT_WINDOW_LENGTH" valid:"^[-+]?([0-9]*(\\.[0-9]*)?[a-z]+)+$"`
 }


### PR DESCRIPTION
This updates cloudinit to prefix REBOOT_WINDOW_* environment
variables with LOCKSMITHD_ when setting up the dropin for the
locksmithd.service unit. This is to be consistent with the other
variables (the unprefixed versions are still supported by
the locksmith daemon).

**Notes**

This will cause the `/run/systemd/system/locksmithd.service.d/20-cloudinit.conf` to output environment variables with `LOCKSMITHD_` prefixed, for `locksmithd` to read. This ties in with the docs https://github.com/coreos/locksmith/blob/master/README.md#reboot-windows and keeps the variable names consistent.